### PR TITLE
feat: support use of pxeurls in machine provisioning

### DIFF
--- a/api/v1alpha3/packetmachine_types.go
+++ b/api/v1alpha3/packetmachine_types.go
@@ -38,6 +38,11 @@ type PacketMachineSpec struct {
 	MachineType  string   `json:"machineType"`
 	SshKeys      []string `json:"sshKeys,omitempty"`
 
+	// IPXEUrl can be used to set the pxe boot url when using custom OSes with this provider.
+	// Note that OS should also be set to "custom_ipxe" if using this value.
+	// +optional
+	IPXEUrl string `json:"ipxeURL,omitempty"`
+
 	// HardwareReservationID is the unique device hardware reservation ID or `next-available` to
 	// automatically let the Packet api determine one.
 	// +optional

--- a/config/resources/crd/bases/infrastructure.cluster.x-k8s.io_packetclusters.yaml
+++ b/config/resources/crd/bases/infrastructure.cluster.x-k8s.io_packetclusters.yaml
@@ -22,14 +22,10 @@ spec:
       description: PacketCluster is the Schema for the packetclusters API
       properties:
         apiVersion:
-          description: 'APIVersion defines the versioned schema of this representation
-            of an object. Servers should convert recognized schemas to the latest
-            internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+          description: 'APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
           type: string
         kind:
-          description: 'Kind is a string value representing the REST resource this
-            object represents. Servers may infer this from the endpoint the client
-            submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+          description: 'Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
           type: string
         metadata:
           type: object
@@ -37,8 +33,7 @@ spec:
           description: PacketClusterSpec defines the desired state of PacketCluster
           properties:
             controlPlaneEndpoint:
-              description: ControlPlaneEndpoint represents the endpoint used to communicate
-                with the control plane.
+              description: ControlPlaneEndpoint represents the endpoint used to communicate with the control plane.
               properties:
                 host:
                   description: The hostname on which the API server is serving.
@@ -55,8 +50,7 @@ spec:
               description: Facility represents the Packet facility for this cluster
               type: string
             projectID:
-              description: ProjectID represents the Packet Project where this cluster
-                will be placed into
+              description: ProjectID represents the Packet Project where this cluster will be placed into
               type: string
           required:
           - projectID

--- a/config/resources/crd/bases/infrastructure.cluster.x-k8s.io_packetmachines.yaml
+++ b/config/resources/crd/bases/infrastructure.cluster.x-k8s.io_packetmachines.yaml
@@ -45,14 +45,10 @@ spec:
       description: PacketMachine is the Schema for the packetmachines API
       properties:
         apiVersion:
-          description: 'APIVersion defines the versioned schema of this representation
-            of an object. Servers should convert recognized schemas to the latest
-            internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+          description: 'APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
           type: string
         kind:
-          description: 'Kind is a string value representing the REST resource this
-            object represents. Servers may infer this from the endpoint the client
-            submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+          description: 'Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
           type: string
         metadata:
           type: object
@@ -64,23 +60,22 @@ spec:
             billingCycle:
               type: string
             hardwareReservationID:
-              description: HardwareReservationID is the unique device hardware reservation
-                ID or `next-available` to automatically let the Packet api determine
-                one.
+              description: HardwareReservationID is the unique device hardware reservation ID or `next-available` to automatically let the Packet api determine one.
+              type: string
+            ipxeURL:
+              description: IPXEUrl can be used to set the pxe boot url when using custom OSes with this provider. Note that OS should also be set to "custom_ipxe" if using this value.
               type: string
             machineType:
               type: string
             providerID:
-              description: ProviderID is the unique identifier as specified by the
-                cloud provider.
+              description: ProviderID is the unique identifier as specified by the cloud provider.
               type: string
             sshKeys:
               items:
                 type: string
               type: array
             tags:
-              description: Tags is an optional set of tags to add to Packet resources
-                managed by the Packet provider.
+              description: Tags is an optional set of tags to add to Packet resources managed by the Packet provider.
               items:
                 type: string
               type: array
@@ -101,8 +96,7 @@ spec:
                     description: The node address.
                     type: string
                   type:
-                    description: Node address type, one of Hostname, ExternalIP or
-                      InternalIP.
+                    description: Node address type, one of Hostname, ExternalIP or InternalIP.
                     type: string
                 required:
                 - address
@@ -110,28 +104,13 @@ spec:
                 type: object
               type: array
             errorMessage:
-              description: "ErrorMessage will be set in the event that there is a
-                terminal problem reconciling the Machine and will contain a more verbose
-                string suitable for logging and human consumption. \n This field should
-                not be set for transitive errors that a controller faces that are
-                expected to be fixed automatically over time (like service outages),
-                but instead indicate that something is fundamentally wrong with the
-                Machine's spec or the configuration of the controller, and that manual
-                intervention is required. Examples of terminal errors would be invalid
-                combinations of settings in the spec, values that are unsupported
-                by the controller, or the responsible controller itself being critically
-                misconfigured. \n Any transient errors that occur during the reconciliation
-                of Machines can be added as events to the Machine object and/or logged
-                in the controller's output."
+              description: "ErrorMessage will be set in the event that there is a terminal problem reconciling the Machine and will contain a more verbose string suitable for logging and human consumption. \n This field should not be set for transitive errors that a controller faces that are expected to be fixed automatically over time (like service outages), but instead indicate that something is fundamentally wrong with the Machine's spec or the configuration of the controller, and that manual intervention is required. Examples of terminal errors would be invalid combinations of settings in the spec, values that are unsupported by the controller, or the responsible controller itself being critically misconfigured. \n Any transient errors that occur during the reconciliation of Machines can be added as events to the Machine object and/or logged in the controller's output."
               type: string
             errorReason:
-              description: Any transient errors that occur during the reconciliation
-                of Machines can be added as events to the Machine object and/or logged
-                in the controller's output.
+              description: Any transient errors that occur during the reconciliation of Machines can be added as events to the Machine object and/or logged in the controller's output.
               type: string
             instanceStatus:
-              description: InstanceStatus is the status of the Packet device instance
-                for this machine.
+              description: InstanceStatus is the status of the Packet device instance for this machine.
               type: string
             ready:
               description: Ready is true when the provider resource is ready.

--- a/config/resources/crd/bases/infrastructure.cluster.x-k8s.io_packetmachinetemplates.yaml
+++ b/config/resources/crd/bases/infrastructure.cluster.x-k8s.io_packetmachinetemplates.yaml
@@ -19,18 +19,13 @@ spec:
   scope: Namespaced
   validation:
     openAPIV3Schema:
-      description: PacketMachineTemplate is the Schema for the packetmachinetemplates
-        API
+      description: PacketMachineTemplate is the Schema for the packetmachinetemplates API
       properties:
         apiVersion:
-          description: 'APIVersion defines the versioned schema of this representation
-            of an object. Servers should convert recognized schemas to the latest
-            internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+          description: 'APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
           type: string
         kind:
-          description: 'Kind is a string value representing the REST resource this
-            object represents. Servers may infer this from the endpoint the client
-            submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+          description: 'Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
           type: string
         metadata:
           type: object
@@ -38,35 +33,32 @@ spec:
           description: PacketMachineTemplateSpec defines the desired state of PacketMachineTemplate
           properties:
             template:
-              description: PacketMachineTemplateResource describes the data needed
-                to create am PacketMachine from a template
+              description: PacketMachineTemplateResource describes the data needed to create am PacketMachine from a template
               properties:
                 spec:
-                  description: Spec is the specification of the desired behavior of
-                    the machine.
+                  description: Spec is the specification of the desired behavior of the machine.
                   properties:
                     OS:
                       type: string
                     billingCycle:
                       type: string
                     hardwareReservationID:
-                      description: HardwareReservationID is the unique device hardware
-                        reservation ID or `next-available` to automatically let the
-                        Packet api determine one.
+                      description: HardwareReservationID is the unique device hardware reservation ID or `next-available` to automatically let the Packet api determine one.
+                      type: string
+                    ipxeURL:
+                      description: IPXEUrl can be used to set the pxe boot url when using custom OSes with this provider. Note that OS should also be set to "custom_ipxe" if using this value.
                       type: string
                     machineType:
                       type: string
                     providerID:
-                      description: ProviderID is the unique identifier as specified
-                        by the cloud provider.
+                      description: ProviderID is the unique identifier as specified by the cloud provider.
                       type: string
                     sshKeys:
                       items:
                         type: string
                       type: array
                     tags:
-                      description: Tags is an optional set of tags to add to Packet
-                        resources managed by the Packet provider.
+                      description: Tags is an optional set of tags to add to Packet resources managed by the Packet provider.
                       items:
                         type: string
                       type: array

--- a/pkg/cloud/packet/client.go
+++ b/pkg/cloud/packet/client.go
@@ -34,6 +34,7 @@ import (
 const (
 	apiTokenVarName = "PACKET_API_KEY"
 	clientName      = "CAPP-v1alpha3"
+	ipxeOS          = "custom_ipxe"
 )
 
 var ErrControlPlanEndpointNotFound = errors.New("contorl plane not found")
@@ -102,6 +103,15 @@ func (p *PacketClient) NewDevice(machineScope *scope.MachineScope, extraTags []s
 		OS:                    machineScope.PacketMachine.Spec.OS,
 		Tags:                  tags,
 		UserData:              userData,
+	}
+
+	// Update server options to pass pxe url if specified
+	if machineScope.PacketMachine.Spec.IPXEUrl != "" {
+		// Error if pxe url and OS conflict
+		if machineScope.PacketMachine.Spec.OS != ipxeOS {
+			return nil, fmt.Errorf("os should be set to custom_pxe when using pxe urls")
+		}
+		serverCreateOpts.IPXEScriptURL = machineScope.PacketMachine.Spec.IPXEUrl
 	}
 
 	dev, _, err := p.Client.Devices.Create(serverCreateOpts)


### PR DESCRIPTION
This PR will add a new field to packetmachine that allows for the
passing of a pxe url string. If present, we check that the OS is also
set to "custom_ipxe" so that we can fail early.

Will close #131 
Related issue #118 

Signed-off-by: Spencer Smith <robertspencersmith@gmail.com>