### PR TITLE
update packet-ccm to 1.0.1 (with a pinned url)

### DIFF
--- a/templates/cluster-template.yaml
+++ b/templates/cluster-template.yaml
@@ -27,7 +27,7 @@ spec:
           cloud-provider: external
     postKubeadmCommands:
     - 'kubectl --kubeconfig /etc/kubernetes/admin.conf create secret generic -n kube-system packet-cloud-config --from-literal=cloud-sa.json=''{"apiKey": "{{ .apiKey }}","projectID": "${PROJECT_ID}"}'''
-    - kubectl apply --kubeconfig /etc/kubernetes/admin.conf -f https://raw.githubusercontent.com/packethost/packet-ccm/master/deploy/releases/v1.0.0/deployment.yaml
+    - kubectl apply --kubeconfig /etc/kubernetes/admin.conf -f https://raw.githubusercontent.com/packethost/packet-ccm/9779a5b1dcaa039c40159a6a2c2e57b8ab4874d8/deploy/releases/v1.0.1/deployment.yaml
     preKubeadmCommands:
     - sed -ri '/\sswap\s/s/^#?/#/' /etc/fstab
     - swapoff -a


### PR DESCRIPTION
This PR Updates the CCM to [1.0.1](https://raw.githubusercontent.com/packethost/packet-ccm/9779a5b1dcaa039c40159a6a2c2e57b8ab4874d8/deploy/releases/v1.0.1/deployment.yaml) and pins the URL to a commit (a tag is not available) so changes on the relative `master` will not break the URL.

Closes #151