### PR TITLE
Teach ccm what it needs to look after the control plane endpoint

### DIFF
--- a/controllers/packetmachine_controller.go
+++ b/controllers/packetmachine_controller.go
@@ -208,6 +208,9 @@ func (r *PacketMachineReconciler) reconcile(ctx context.Context, machineScope *s
 		}
 	}
 	if dev == nil {
+		createDeviceReq := packet.CreateDeviceRequest{
+			MachineScope: machineScope,
+		}
 		mUID := uuid.New().String()
 		tags := []string{
 			packet.GenerateMachineTag(mUID),
@@ -228,13 +231,13 @@ func (r *PacketMachineReconciler) reconcile(ctx context.Context, machineScope *s
 					Address: controlPlaneEndpoint.Address,
 				}
 				addrs = append(addrs, a)
-				// This tag is currently not used. I placed it there to easely localize the device that currently has the IP attached.
-				// Probably it is not neeed but I wil get back to it when working at #141.
-				tags = append(tags, fmt.Sprintf("capp.control-plane-endpoint=%s", controlPlaneEndpoint.Address))
 			}
+			createDeviceReq.ControlPlaneEndpoint = controlPlaneEndpoint.Address
 		}
 
-		dev, err = r.PacketClient.NewDevice(machineScope, tags)
+		createDeviceReq.ExtraTags = tags
+
+		dev, err = r.PacketClient.NewDevice(createDeviceReq)
 		if err != nil {
 			errs := fmt.Errorf("failed to create machine %s: %v", machineScope.Name(), err)
 			machineScope.SetErrorReason(capierrors.CreateMachineError)

--- a/templates/cluster-template.yaml
+++ b/templates/cluster-template.yaml
@@ -26,6 +26,14 @@ spec:
         kubeletExtraArgs:
           cloud-provider: external
     postKubeadmCommands:
+    - |
+        cat <<EOF >> /etc/network/interfaces
+        auto lo:0
+        iface lo:0 inet static
+          address {{ .controlPlaneEndpoint }}
+          netmask 255.255.255.255
+        EOF
+    - systemctl restart networking
     - 'kubectl --kubeconfig /etc/kubernetes/admin.conf create secret generic -n kube-system packet-cloud-config --from-literal=cloud-sa.json=''{"apiKey": "{{ .apiKey }}","projectID": "${PROJECT_ID}"}'''
     - kubectl apply --kubeconfig /etc/kubernetes/admin.conf -f https://raw.githubusercontent.com/packethost/packet-ccm/9779a5b1dcaa039c40159a6a2c2e57b8ab4874d8/deploy/releases/v1.0.1/deployment.yaml
     preKubeadmCommands:
@@ -44,14 +52,7 @@ spec:
     - systemctl daemon-reload
     - systemctl enable docker
     - systemctl start docker
-    - |
-        cat <<EOF >> /etc/network/interfaces
-        auto lo:0
-        iface lo:0 inet static
-          address $(curl -s https://metadata.packet.net/metadata | jq -r '.network.addresses[] | select(.address_family == 4 and .public == true and .management == false) | .address')
-          netmask 255.255.255.255
-        EOF
-    - systemctl restart networking
+    - ping -c 3 -q {{ .controlPlaneEndpoint }} && echo OK || ip addr add {{ .controlPlaneEndpoint }} dev lo
 ---
 apiVersion: infrastructure.cluster.x-k8s.io/v1alpha3
 kind: PacketMachineTemplate


### PR DESCRIPTION
One of the Packet CCM responsability is to check the status of the
Control Plane Endpoint (an elastic ip) keeping it assigned to an healthy
control plane.

In order to do that it needs to know the key=pair used to tag the
elastic ip at creation phase. This PR pass this information to CCM via
Kubernetes Secret