### PR TITLE
The addresses do not contains the right value but a Go obj

### DIFF
--- a/pkg/cloud/packet/client.go
+++ b/pkg/cloud/packet/client.go
@@ -136,7 +136,7 @@ func (p *PacketClient) GetDeviceAddresses(device *packngo.Device) ([]corev1.Node
 		}
 		a := corev1.NodeAddress{
 			Type:    addrType,
-			Address: addr.String(),
+			Address: addr.Address,
 		}
 		addrs = append(addrs, a)
 	}


### PR DESCRIPTION
When converting the IPs from the device to kubernetes machine I didn't
render the right content (just the IP) but the entire Go object.

Fixed #157 

/kind bug
/assign @deitch 