### PR TITLE
Update module path to sigs.k8s.io/cluster-api-provider-packet

### DIFF
--- a/PROJECT
+++ b/PROJECT
@@ -1,5 +1,5 @@
 domain: cluster.x-k8s.io
-repo: github.com/packethost/cluster-api-provider-packet
+repo: sigs.k8s.io/cluster-api-provider-packet
 resources:
 - group: infrastructure
   kind: PacketCluster

--- a/README.md
+++ b/README.md
@@ -1,5 +1,11 @@
 # Packet cluster-api Provider
 
+[![GitHub release](https://img.shields.io/github/release/kubernetes-sigs/cluster-api-provider-packet/all.svg?style=flat-square)](https://github.com/kubernetes-sigs/cluster-api-provider-packet/releases)
+![Continuous Integration](https://github.com/kubernetes-sigs/cluster-api-provider-packet/workflows/Continuous%20Integration/badge.svg)
+[![GoDoc](https://godoc.org/sigs.k8s.io/cluster-api-provider-packet?status.svg)](https://pkg.go.dev/sigs.k8s.io/cluster-api-provider-packet?tab=overview)
+[![Go Report Card](https://goreportcard.com/badge/sigs.k8s.io/cluster-api-provider-packet)](https://goreportcard.com/report/sigs.k8s.io/cluster-api-provider-packet)
+[![Docker Pulls](https://img.shields.io/docker/pulls/packethost/cluster-api-provider-packet.svg)](https://hub.docker.com/r/packethost/cluster-api-provider-packet/)
+
 This is the official [cluster-api](https://github.com/kubernetes-sigs/cluster-api) provider for [Packet](https://packet.com). It implements cluster-api provider version v1alpha3.
 
 ## Using

--- a/controllers/packetcluster_controller.go
+++ b/controllers/packetcluster_controller.go
@@ -32,10 +32,10 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/handler"
 	"sigs.k8s.io/controller-runtime/pkg/source"
 
-	"github.com/packethost/cluster-api-provider-packet/api/v1alpha3"
-	infrastructurev1alpha3 "github.com/packethost/cluster-api-provider-packet/api/v1alpha3"
-	packet "github.com/packethost/cluster-api-provider-packet/pkg/cloud/packet"
-	"github.com/packethost/cluster-api-provider-packet/pkg/cloud/packet/scope"
+	"sigs.k8s.io/cluster-api-provider-packet/api/v1alpha3"
+	infrastructurev1alpha3 "sigs.k8s.io/cluster-api-provider-packet/api/v1alpha3"
+	packet "sigs.k8s.io/cluster-api-provider-packet/pkg/cloud/packet"
+	"sigs.k8s.io/cluster-api-provider-packet/pkg/cloud/packet/scope"
 )
 
 // PacketClusterReconciler reconciles a PacketCluster object

--- a/controllers/packetmachine_controller.go
+++ b/controllers/packetmachine_controller.go
@@ -39,12 +39,13 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 	"sigs.k8s.io/controller-runtime/pkg/handler"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 	"sigs.k8s.io/controller-runtime/pkg/source"
 
-	packet "github.com/packethost/cluster-api-provider-packet/pkg/cloud/packet"
-	"github.com/packethost/cluster-api-provider-packet/pkg/cloud/packet/scope"
+	packet "sigs.k8s.io/cluster-api-provider-packet/pkg/cloud/packet"
+	"sigs.k8s.io/cluster-api-provider-packet/pkg/cloud/packet/scope"
 
-	infrastructurev1alpha3 "github.com/packethost/cluster-api-provider-packet/api/v1alpha3"
+	infrastructurev1alpha3 "sigs.k8s.io/cluster-api-provider-packet/api/v1alpha3"
 )
 
 const (

--- a/controllers/packetmachine_controller.go
+++ b/controllers/packetmachine_controller.go
@@ -49,8 +49,7 @@ import (
 )
 
 const (
-	providerName = "packet"
-	force        = true
+	force = true
 )
 
 // PacketMachineReconciler reconciles a PacketMachine object
@@ -260,7 +259,7 @@ func (r *PacketMachineReconciler) reconcile(ctx context.Context, machineScope *s
 	machineScope.SetAddresses(append(addrs, deviceAddr...))
 
 	// Proceed to reconcile the PacketMachine state.
-	var result = ctrl.Result{}
+	var result reconcile.Result
 
 	switch infrastructurev1alpha3.PacketResourceStatus(dev.State) {
 	case infrastructurev1alpha3.PacketResourceStatusNew, infrastructurev1alpha3.PacketResourceStatusQueued, infrastructurev1alpha3.PacketResourceStatusProvisioning:

--- a/controllers/suite_test.go
+++ b/controllers/suite_test.go
@@ -32,7 +32,7 @@ import (
 	logf "sigs.k8s.io/controller-runtime/pkg/log"
 	"sigs.k8s.io/controller-runtime/pkg/log/zap"
 
-	infrastructurev1alpha3 "github.com/packethost/cluster-api-provider-packet/api/v1alpha3"
+	infrastructurev1alpha3 "sigs.k8s.io/cluster-api-provider-packet/api/v1alpha3"
 	clusterv1 "sigs.k8s.io/cluster-api/api/v1alpha3"
 	// +kubebuilder:scaffold:imports
 )

--- a/docs/concepts/machine.md
+++ b/docs/concepts/machine.md
@@ -25,6 +25,8 @@ full list of supported parameters as part of the OpenAPI definition available
 [here](config/resources/crd/bases/infrastructure.cluster.x-k8s.io_packetmachines.yaml)
 searching for `kind: PacketMachine`.
 
+The `PacketMachine`, `PacketCluster`, and `PacketMachineTemplate` CRD specs are also documented at [docs.crds.dev](https://doc.crds.dev/github.com/kubernetes-sigs/cluster-api-provider-packet).
+
 ## Reserved instances
 
 Packet provides the possibility to [reserve

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/packethost/cluster-api-provider-packet
+module sigs.k8s.io/cluster-api-provider-packet
 
 go 1.13
 

--- a/go.sum
+++ b/go.sum
@@ -74,8 +74,6 @@ github.com/davecgh/go-spew v0.0.0-20151105211317-5215b55f46b2/go.mod h1:J7Y8YcW2
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
-github.com/deitch/packngo v0.2.1-0.20200628082620-d644bb21e1f3 h1:ph32bLs6ix+iPhSP4oapLhlpIwW1n9I9e7wELpnvBfI=
-github.com/deitch/packngo v0.2.1-0.20200628082620-d644bb21e1f3/go.mod h1:erURcsqYzwc9wSb04TX4so+s6F3uZtbXUil0W1LCGHA=
 github.com/dgrijalva/jwt-go v3.2.0+incompatible/go.mod h1:E3ru+11k8xSBh+hMPgOLZmtrrCbhqsmaPHjLKYnJCaQ=
 github.com/dgryski/go-sip13 v0.0.0-20181026042036-e10d5fee7954/go.mod h1:vAd38F8PWV+bWy6jNmig1y/TA+kYO4g3RSRF0IAv0no=
 github.com/docker/distribution v2.7.1+incompatible h1:a5mlkVzth6W5A4fOsS3D2EO5BUmsJpcB+cRlLU7cSug=
@@ -322,8 +320,6 @@ github.com/onsi/gomega v1.9.0 h1:R1uwffexN6Pr340GtYRIdZmAiN4J+iw6WG4wog1DUXg=
 github.com/onsi/gomega v1.9.0/go.mod h1:Ho0h+IUsWyvy1OpqCwxlQ/21gkhVunqlU8fDGcoTdcA=
 github.com/opencontainers/go-digest v1.0.0-rc1 h1:WzifXhOVOEOuFYOJAW6aQqW0TooG2iki3E3Ii+WN7gQ=
 github.com/opencontainers/go-digest v1.0.0-rc1/go.mod h1:cMLVZDEM3+U2I4VmLI6N8jQYUd2OVphdqWwCJHrFt2s=
-github.com/packethost/packngo v0.2.0 h1:mSlzOof8PsOWCy78sBMt/PwMJTEjjQ/rRvMixu4Nm6c=
-github.com/packethost/packngo v0.2.0/go.mod h1:RQHg5xR1F614BwJyepfMqrKN+32IH0i7yX+ey43rEeQ=
 github.com/packethost/packngo v0.2.1-0.20200629161839-1810e48469b4 h1:T6L0ioYOSzOfX9/DzmeXMOuqJb3GldrVHJe4lLJw3Bk=
 github.com/packethost/packngo v0.2.1-0.20200629161839-1810e48469b4/go.mod h1:erURcsqYzwc9wSb04TX4so+s6F3uZtbXUil0W1LCGHA=
 github.com/pborman/uuid v1.2.0/go.mod h1:X/NO0urCmaxf9VXbdlT7C2Yzkj2IKimNn4k+gtPdI/k=

--- a/hack/tools/go.mod
+++ b/hack/tools/go.mod
@@ -1,4 +1,4 @@
-module github.com/packethost/cluster-api-provider-packet/hack/tools
+module sigs.k8s.io/cluster-api-provider-packet/hack/tools
 
 go 1.14
 

--- a/main.go
+++ b/main.go
@@ -26,10 +26,10 @@ import (
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/log/zap"
 
-	packet "github.com/packethost/cluster-api-provider-packet/pkg/cloud/packet"
+	packet "sigs.k8s.io/cluster-api-provider-packet/pkg/cloud/packet"
 
-	infrastructurev1alpha3 "github.com/packethost/cluster-api-provider-packet/api/v1alpha3"
-	"github.com/packethost/cluster-api-provider-packet/controllers"
+	infrastructurev1alpha3 "sigs.k8s.io/cluster-api-provider-packet/api/v1alpha3"
+	"sigs.k8s.io/cluster-api-provider-packet/controllers"
 	clusterv1 "sigs.k8s.io/cluster-api/api/v1alpha3"
 	// +kubebuilder:scaffold:imports
 )

--- a/pkg/cloud/packet/client.go
+++ b/pkg/cloud/packet/client.go
@@ -24,11 +24,11 @@ import (
 	"strings"
 	"text/template"
 
-	infrastructurev1alpha3 "github.com/packethost/cluster-api-provider-packet/api/v1alpha3"
-	"github.com/packethost/cluster-api-provider-packet/pkg/cloud/packet/scope"
 	"github.com/packethost/packngo"
 	"github.com/pkg/errors"
 	corev1 "k8s.io/api/core/v1"
+	infrastructurev1alpha3 "sigs.k8s.io/cluster-api-provider-packet/api/v1alpha3"
+	"sigs.k8s.io/cluster-api-provider-packet/pkg/cloud/packet/scope"
 )
 
 const (

--- a/pkg/cloud/packet/scope/cluster.go
+++ b/pkg/cloud/packet/scope/cluster.go
@@ -22,7 +22,7 @@ import (
 	"github.com/go-logr/logr"
 	"github.com/pkg/errors"
 
-	infrav1 "github.com/packethost/cluster-api-provider-packet/api/v1alpha3"
+	infrav1 "sigs.k8s.io/cluster-api-provider-packet/api/v1alpha3"
 
 	"k8s.io/klog/klogr"
 

--- a/pkg/cloud/packet/scope/machine.go
+++ b/pkg/cloud/packet/scope/machine.go
@@ -23,7 +23,7 @@ import (
 	"github.com/go-logr/logr"
 	"github.com/pkg/errors"
 
-	infrav1 "github.com/packethost/cluster-api-provider-packet/api/v1alpha3"
+	infrav1 "sigs.k8s.io/cluster-api-provider-packet/api/v1alpha3"
 
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/types"


### PR DESCRIPTION
In this PR:
* package name was updated to `sigs.k8s.io/cluster-api-provider-packet`
* `go mod tidy` was run
* README badges were added (some referring to the new package name which won't work until after this is merged)
* golanglint-ci linter warnings were corrected (unused `packageName`, ineffectual assignment)
* Link was added to <https://doc.crds.dev/github.com/kubernetes-sigs/cluster-api-provider-packet/> when discussing the `PacketMachine` spec

There are still references to `packethost/cluster-api-provider-packet` in the context of the Docker repo.

There are still references to `kubernetes-sigs/cluster-api-provider-packet` in the context of Github issues, releases, and workflows.

Closes #164 