### PR TITLE
Enable Control Plane elastic ip management in CCM

### DIFF
--- a/templates/cluster-template.yaml
+++ b/templates/cluster-template.yaml
@@ -34,7 +34,7 @@ spec:
           netmask 255.255.255.255
         EOF
     - systemctl restart networking
-    - 'kubectl --kubeconfig /etc/kubernetes/admin.conf create secret generic -n kube-system packet-cloud-config --from-literal=cloud-sa.json=''{"apiKey": "{{ .apiKey }}","projectID": "${PROJECT_ID}"}'''
+    - 'kubectl --kubeconfig /etc/kubernetes/admin.conf create secret generic -n kube-system packet-cloud-config --from-literal=cloud-sa.json=''{"apiKey": "{{ .apiKey }}","projectID": "${PROJECT_ID}", "eipTag": "cluster-api-provider-packet:cluster-id:${CLUSTER_NAME}"}'''
     - kubectl apply --kubeconfig /etc/kubernetes/admin.conf -f https://github.com/packethost/packet-ccm/releases/download/v1.1.0/deployment.yaml
     preKubeadmCommands:
     - sed -ri '/\sswap\s/s/^#?/#/' /etc/fstab


### PR DESCRIPTION
This PR enables the Elastip IP management for Control Plane in CCM.

One of the Packet CCM responsibility is to health check the Control
Plane IP and move the Elastic IP to an healthy control plane.

In order to do that the configuration has to be set to CCM secret.