### PR TITLE
✨ manager: add health probes

### DIFF
--- a/config/resources/manager/manager.yaml
+++ b/config/resources/manager/manager.yaml
@@ -23,6 +23,18 @@ spec:
         image: packet-controller
         imagePullPolicy: IfNotPresent
         name: manager
+        ports:
+        - containerPort: 9440
+          name: healthz
+          protocol: TCP
+        readinessProbe:
+          httpGet:
+            path: /readyz
+            port: healthz
+        livenessProbe:
+          httpGet:
+            path: /healthz
+            port: healthz
         resources:
           limits:
             cpu: 100m


### PR DESCRIPTION
Similar was made here https://github.com/kubernetes-sigs/cluster-api-provider-aws/pull/1487 and https://github.com/kubernetes-sigs/cluster-api/pull/2156

Adding the liveness and readiness probes for cluster-api-provider-packet