### PR TITLE
🐛 clusterctl init fail because manager does not use a canonical image name

### DIFF
--- a/config/release/kustomization.yaml
+++ b/config/release/kustomization.yaml
@@ -24,7 +24,7 @@ resources:
 images:
 - name: packet-controller # images with this name
   newTag: v0.3.2 # {"type":"string","x-kustomize":{"setter":{"name":"image-tag","value":"v0.3.2"}}}
-  newName: packethost/cluster-api-provider-packet # and this name
+  newName: docker.io/packethost/cluster-api-provider-packet # and this name
 patchesStrategicMerge:
 # Protect the /metrics endpoint by putting it behind auth.
 # If you want your controller-manager to expose the /metrics


### PR DESCRIPTION
Probably there is a new check that prevents clusterctl to work if an
the image does not follow the canonical naming convention.

This PR should fix this issue and it should make `clusterctl init` working
again.

fixed #184