### PR TITLE
fix: use correct namespace name

### DIFF
--- a/config/resources/namespace/namespace.yaml
+++ b/config/resources/namespace/namespace.yaml
@@ -3,4 +3,4 @@ kind: Namespace
 metadata:
   labels:
     control-plane: controller-manager
-  name: system
+  name: cluster-api-provider-packet-system


### PR DESCRIPTION
**What this PR does / why we need it**:

The `infrastructure-components.yaml` generated in the release has a namespace resource called `system`, which seems incorrect and the YAML cannot be applied directly. Based on the other resources, this namespace should be called `cluster-api-provider-packet-system`

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #
