### PR TITLE
feat: allow installation of the latest semantic version

### DIFF
--- a/templates/cluster-template.yaml
+++ b/templates/cluster-template.yaml
@@ -48,7 +48,9 @@ spec:
     - apt-key fingerprint 0EBFCD88
     - add-apt-repository "deb [arch=amd64] https://download.docker.com/linux/ubuntu $(lsb_release -cs) stable"
     - apt-get update -y
-    - apt-get install -y ca-certificates socat jq ebtables apt-transport-https cloud-utils prips docker-ce docker-ce-cli containerd.io kubelet kubeadm kubectl
+    - TRIMMED_KUBERNETES_VERSION=$(echo $KUBERNETES_VERSION | sed 's/\./\\./g' | sed 's/^v//')
+    - RESOLVED_KUBERNETES_VERSION=$(apt-cache policy kubelet | awk -v "VERSION=${TRIMMED_KUBERNETES_VERSION}" '$1~ VERSION { print $1 }' | head -n1)
+    - apt-get install -y ca-certificates socat jq ebtables apt-transport-https cloud-utils prips docker-ce docker-ce-cli containerd.io kubelet=${RESOLVED_KUBERNETES_VERSION} kubeadm=${RESOLVED_KUBERNETES_VERSION} kubectl=${RESOLVED_KUBERNETES_VERSION}
     - systemctl daemon-reload
     - systemctl enable docker
     - systemctl start docker
@@ -160,7 +162,9 @@ spec:
         - apt-key fingerprint 0EBFCD88
         - add-apt-repository "deb [arch=amd64] https://download.docker.com/linux/ubuntu $(lsb_release -cs) stable"
         - apt-get update -y
-        - apt-get install -y ca-certificates socat jq ebtables apt-transport-https cloud-utils prips docker-ce docker-ce-cli containerd.io kubelet kubeadm kubectl
+        - TRIMMED_KUBERNETES_VERSION=$(echo $KUBERNETES_VERSION | sed 's/\./\\./g' | sed 's/^v//')
+        - RESOLVED_KUBERNETES_VERSION=$(apt-cache policy kubelet | awk -v "VERSION=${TRIMMED_KUBERNETES_VERSION}" '$1~ VERSION { print $1 }' | head -n1)
+        - apt-get install -y ca-certificates socat jq ebtables apt-transport-https cloud-utils prips docker-ce docker-ce-cli containerd.io kubelet=${RESOLVED_KUBERNETES_VERSION} kubeadm=${RESOLVED_KUBERNETES_VERSION} kubectl=${RESOLVED_KUBERNETES_VERSION}
         - systemctl daemon-reload
         - systemctl enable docker
         - systemctl start docker


### PR DESCRIPTION
This PR fetches all the version from the apt cache and filters based on the `KUBERNETES_VERSION` provided by the cluster configuration.

This PR doesn't pin / hold that installed version, meaning that it should still be able to upgrade as expected; I need to provide tests for this.