### PR TITLE
:running: e2e fixes

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -226,9 +226,13 @@ $(KUBEBUILDER):
 test: generate fmt vet crds
 	go test ./... -coverprofile cover.out
 
+.PHONY: e2e-image
+e2e-image:
+	docker build --tag=docker.io/packethost/cluster-api-provider-packet:e2e .
+
 # Run e2e tests
 .PHONY: e2e
-e2e:
+e2e: e2e-image
 	# This is the name used inside the component.yaml for the container that runs the manager
 	# The image gets loaded inside kind from ./test/e2e/config/packet-dev.yaml
 	$(E2E_FLAGS) $(MAKE) -C $(TEST_E2E_DIR) run

--- a/config/kustomization.yaml
+++ b/config/kustomization.yaml
@@ -12,6 +12,6 @@ bases:
 #- webhook # Disable this if you're not using the webhook functionality.
 - default
 images:
-- name: packet-controller # images with this name
+- name: docker.io/packethost/cluster-api-provider-packet:e2e # images with this name
   newTag: v0.3.5 # {"type":"string","x-kustomize":{"setter":{"name":"image-tag","value":"v0.3.5"}}}
   newName: docker.io/packethost/cluster-api-provider-packet # and this name

--- a/config/manager/manager_image_patch.yaml
+++ b/config/manager/manager_image_patch.yaml
@@ -8,5 +8,5 @@ spec:
     spec:
       containers:
       # Change the value of image field below to your controller image URL
-      - image: packethost/cluster-api-provider-packet
+      - image: docker.io/packethost/cluster-api-provider-packet:e2e
         name: manager

--- a/test/e2e/config/packet-dev.yaml
+++ b/test/e2e/config/packet-dev.yaml
@@ -57,7 +57,7 @@ providers:
     - old: "--enable-leader-election"
       new: "--enable-leader-election=false"
   files:
-  - sourcePath: "../../../../metadata.yaml"
+  - sourcePath: "../../../metadata.yaml"
     targetName: "metadata.yaml"
   - sourcePath: "../../../templates/cluster-template.yaml"
 

--- a/test/e2e/config/packet-dev.yaml
+++ b/test/e2e/config/packet-dev.yaml
@@ -3,13 +3,13 @@
 # - cluster-api
 # - bootstrap kubeadm
 # - control-plane kubeadm
+# - packet
 
 images:
-- name: "packethost/cluster-api-packet-controller"
+- name: "docker.io/packethost/cluster-api-provider-packet:e2e"
   loadBehavior: mustLoad
 
 providers:
-
 - name: cluster-api
   type: CoreProvider
   versions:
@@ -51,11 +51,6 @@ providers:
   versions:
   - name: v0.3.0
     value: "../../../config"
-    replacements:
-    - old: "imagePullPolicy: Always"
-      new: "imagePullPolicy: IfNotPresent"
-    - old: "--enable-leader-election"
-      new: "--enable-leader-election=false"
   files:
   - sourcePath: "../../../metadata.yaml"
     targetName: "metadata.yaml"


### PR DESCRIPTION
**What this PR does / why we need it**:

Fixes up issues with the e2e test configuration

Builds on top of https://github.com/kubernetes-sigs/cluster-api-provider-packet/pull/197