### PR TITLE
:sparkles: Fix typo in error message

### DIFF
--- a/pkg/cloud/packet/client.go
+++ b/pkg/cloud/packet/client.go
@@ -37,7 +37,7 @@ const (
 	ipxeOS          = "custom_ipxe"
 )
 
-var ErrControlPlanEndpointNotFound = errors.New("contorl plane not found")
+var ErrControlPlanEndpointNotFound = errors.New("control plane not found")
 
 type PacketClient struct {
 	*packngo.Client


### PR DESCRIPTION
**What this PR does / why we need it**:

Fixes a typo in an error message

