### PR TITLE
:sparkles: templates/cluster-template.yaml: consistently don't use sudo

### DIFF
--- a/templates/cluster-template.yaml
+++ b/templates/cluster-template.yaml
@@ -41,14 +41,14 @@ spec:
       - swapoff -a
       - mount -a
       - |
-        cat <<EOF | sudo tee /etc/modules-load.d/containerd.conf
+        cat <<EOF > /etc/modules-load.d/containerd.conf
         overlay
         br_netfilter
         EOF
       - modprobe overlay
       - modprobe br_netfilter
       - |
-        cat <<EOF | sudo tee /etc/sysctl.d/99-kubernetes-cri.conf
+        cat <<EOF > /etc/sysctl.d/99-kubernetes-cri.conf
         net.bridge.bridge-nf-call-iptables  = 1
         net.ipv4.ip_forward                 = 1
         net.bridge.bridge-nf-call-ip6tables = 1
@@ -56,7 +56,7 @@ spec:
       - sysctl --system
       - apt-get -y update
       - DEBIAN_FRONTEND=noninteractive apt-get install -y apt-transport-https curl
-      - curl -s https://packages.cloud.google.com/apt/doc/apt-key.gpg | sudo apt-key add -
+      - curl -s https://packages.cloud.google.com/apt/doc/apt-key.gpg | apt-key add -
       - echo "deb https://apt.kubernetes.io/ kubernetes-xenial main" > /etc/apt/sources.list.d/kubernetes.list
       - apt-get update -y
       - TRIMMED_KUBERNETES_VERSION=$(echo ${KUBERNETES_VERSION} | sed 's/\./\\./g' | sed 's/^v//')
@@ -168,14 +168,14 @@ spec:
         - swapoff -a
         - mount -a
         - |
-          cat <<EOF | sudo tee /etc/modules-load.d/containerd.conf
+          cat <<EOF > /etc/modules-load.d/containerd.conf
           overlay
           br_netfilter
           EOF
         - modprobe overlay
         - modprobe br_netfilter
         - |
-          cat <<EOF | sudo tee /etc/sysctl.d/99-kubernetes-cri.conf
+          cat <<EOF > /etc/sysctl.d/99-kubernetes-cri.conf
           net.bridge.bridge-nf-call-iptables  = 1
           net.ipv4.ip_forward                 = 1
           net.bridge.bridge-nf-call-ip6tables = 1
@@ -183,7 +183,7 @@ spec:
         - sysctl --system
         - apt-get -y update
         - DEBIAN_FRONTEND=noninteractive apt-get install -y apt-transport-https curl
-        - curl -s https://packages.cloud.google.com/apt/doc/apt-key.gpg | sudo apt-key add -
+        - curl -s https://packages.cloud.google.com/apt/doc/apt-key.gpg | apt-key add -
         - echo "deb https://apt.kubernetes.io/ kubernetes-xenial main" > /etc/apt/sources.list.d/kubernetes.list
         - apt-get update -y
         - TRIMMED_KUBERNETES_VERSION=$(echo ${KUBERNETES_VERSION} | sed 's/\./\\./g' | sed 's/^v//')


### PR DESCRIPTION
**What this PR does / why we need it**:

Other commands which are executed are also privileged, so using sudo
shouldn't be needed.

This is nice to enhance the consistency.

Signed-off-by: Mateusz Gozdek <mateusz@kinvolk.io>
