### PR TITLE
✨  Allow overriding facility

### DIFF
--- a/api/v1alpha3/packetmachine_types.go
+++ b/api/v1alpha3/packetmachine_types.go
@@ -38,6 +38,10 @@ type PacketMachineSpec struct {
 	MachineType  string   `json:"machineType"`
 	SshKeys      []string `json:"sshKeys,omitempty"`
 
+	// Facility represents the Packet facility for this cluster.
+	// Override from the PacketCluster spec.
+	Facility string `json:"facility,omitempty"`
+
 	// IPXEUrl can be used to set the pxe boot url when using custom OSes with this provider.
 	// Note that OS should also be set to "custom_ipxe" if using this value.
 	// +optional

--- a/api/v1alpha3/packetmachine_types.go
+++ b/api/v1alpha3/packetmachine_types.go
@@ -40,6 +40,7 @@ type PacketMachineSpec struct {
 
 	// Facility represents the Packet facility for this cluster.
 	// Override from the PacketCluster spec.
+	// +optional
 	Facility string `json:"facility,omitempty"`
 
 	// IPXEUrl can be used to set the pxe boot url when using custom OSes with this provider.

--- a/config/crd/bases/infrastructure.cluster.x-k8s.io_packetclusters.yaml
+++ b/config/crd/bases/infrastructure.cluster.x-k8s.io_packetclusters.yaml
@@ -1,3 +1,5 @@
+
+---
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
@@ -20,14 +22,10 @@ spec:
         description: PacketCluster is the Schema for the packetclusters API
         properties:
           apiVersion:
-            description: 'APIVersion defines the versioned schema of this representation
-              of an object. Servers should convert recognized schemas to the latest
-              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            description: 'APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
             type: string
           kind:
-            description: 'Kind is a string value representing the REST resource this
-              object represents. Servers may infer this from the endpoint the client
-              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            description: 'Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
             type: string
           metadata:
             type: object
@@ -35,8 +33,7 @@ spec:
             description: PacketClusterSpec defines the desired state of PacketCluster
             properties:
               controlPlaneEndpoint:
-                description: ControlPlaneEndpoint represents the endpoint used to
-                  communicate with the control plane.
+                description: ControlPlaneEndpoint represents the endpoint used to communicate with the control plane.
                 properties:
                   host:
                     description: The hostname on which the API server is serving.
@@ -53,8 +50,7 @@ spec:
                 description: Facility represents the Packet facility for this cluster
                 type: string
               projectID:
-                description: ProjectID represents the Packet Project where this cluster
-                  will be placed into
+                description: ProjectID represents the Packet Project where this cluster will be placed into
                 type: string
             required:
             - projectID

--- a/config/crd/bases/infrastructure.cluster.x-k8s.io_packetmachines.yaml
+++ b/config/crd/bases/infrastructure.cluster.x-k8s.io_packetmachines.yaml
@@ -1,3 +1,5 @@
+
+---
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
@@ -43,14 +45,10 @@ spec:
         description: PacketMachine is the Schema for the packetmachines API
         properties:
           apiVersion:
-            description: 'APIVersion defines the versioned schema of this representation
-              of an object. Servers should convert recognized schemas to the latest
-              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            description: 'APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
             type: string
           kind:
-            description: 'Kind is a string value representing the REST resource this
-              object represents. Servers may infer this from the endpoint the client
-              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            description: 'Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
             type: string
           metadata:
             type: object
@@ -61,29 +59,26 @@ spec:
                 type: string
               billingCycle:
                 type: string
+              facility:
+                description: Facility represents the Packet facility for this cluster. Override from the PacketCluster spec.
+                type: string
               hardwareReservationID:
-                description: HardwareReservationID is the unique device hardware reservation
-                  ID or `next-available` to automatically let the Packet api determine
-                  one.
+                description: HardwareReservationID is the unique device hardware reservation ID or `next-available` to automatically let the Packet api determine one.
                 type: string
               ipxeURL:
-                description: IPXEUrl can be used to set the pxe boot url when using
-                  custom OSes with this provider. Note that OS should also be set
-                  to "custom_ipxe" if using this value.
+                description: IPXEUrl can be used to set the pxe boot url when using custom OSes with this provider. Note that OS should also be set to "custom_ipxe" if using this value.
                 type: string
               machineType:
                 type: string
               providerID:
-                description: ProviderID is the unique identifier as specified by the
-                  cloud provider.
+                description: ProviderID is the unique identifier as specified by the cloud provider.
                 type: string
               sshKeys:
                 items:
                   type: string
                 type: array
               tags:
-                description: Tags is an optional set of tags to add to Packet resources
-                  managed by the Packet provider.
+                description: Tags is an optional set of tags to add to Packet resources managed by the Packet provider.
                 items:
                   type: string
                 type: array
@@ -104,8 +99,7 @@ spec:
                       description: The node address.
                       type: string
                     type:
-                      description: Node address type, one of Hostname, ExternalIP
-                        or InternalIP.
+                      description: Node address type, one of Hostname, ExternalIP or InternalIP.
                       type: string
                   required:
                   - address
@@ -113,28 +107,13 @@ spec:
                   type: object
                 type: array
               errorMessage:
-                description: "ErrorMessage will be set in the event that there is
-                  a terminal problem reconciling the Machine and will contain a more
-                  verbose string suitable for logging and human consumption. \n This
-                  field should not be set for transitive errors that a controller
-                  faces that are expected to be fixed automatically over time (like
-                  service outages), but instead indicate that something is fundamentally
-                  wrong with the Machine's spec or the configuration of the controller,
-                  and that manual intervention is required. Examples of terminal errors
-                  would be invalid combinations of settings in the spec, values that
-                  are unsupported by the controller, or the responsible controller
-                  itself being critically misconfigured. \n Any transient errors that
-                  occur during the reconciliation of Machines can be added as events
-                  to the Machine object and/or logged in the controller's output."
+                description: "ErrorMessage will be set in the event that there is a terminal problem reconciling the Machine and will contain a more verbose string suitable for logging and human consumption. \n This field should not be set for transitive errors that a controller faces that are expected to be fixed automatically over time (like service outages), but instead indicate that something is fundamentally wrong with the Machine's spec or the configuration of the controller, and that manual intervention is required. Examples of terminal errors would be invalid combinations of settings in the spec, values that are unsupported by the controller, or the responsible controller itself being critically misconfigured. \n Any transient errors that occur during the reconciliation of Machines can be added as events to the Machine object and/or logged in the controller's output."
                 type: string
               errorReason:
-                description: Any transient errors that occur during the reconciliation
-                  of Machines can be added as events to the Machine object and/or
-                  logged in the controller's output.
+                description: Any transient errors that occur during the reconciliation of Machines can be added as events to the Machine object and/or logged in the controller's output.
                 type: string
               instanceStatus:
-                description: InstanceStatus is the status of the Packet device instance
-                  for this machine.
+                description: InstanceStatus is the status of the Packet device instance for this machine.
                 type: string
               ready:
                 description: Ready is true when the provider resource is ready.

--- a/config/crd/bases/infrastructure.cluster.x-k8s.io_packetmachinetemplates.yaml
+++ b/config/crd/bases/infrastructure.cluster.x-k8s.io_packetmachinetemplates.yaml
@@ -1,3 +1,5 @@
+
+---
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
@@ -19,18 +21,13 @@ spec:
   - name: v1alpha3
     schema:
       openAPIV3Schema:
-        description: PacketMachineTemplate is the Schema for the packetmachinetemplates
-          API
+        description: PacketMachineTemplate is the Schema for the packetmachinetemplates API
         properties:
           apiVersion:
-            description: 'APIVersion defines the versioned schema of this representation
-              of an object. Servers should convert recognized schemas to the latest
-              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            description: 'APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
             type: string
           kind:
-            description: 'Kind is a string value representing the REST resource this
-              object represents. Servers may infer this from the endpoint the client
-              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            description: 'Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
             type: string
           metadata:
             type: object
@@ -38,40 +35,35 @@ spec:
             description: PacketMachineTemplateSpec defines the desired state of PacketMachineTemplate
             properties:
               template:
-                description: PacketMachineTemplateResource describes the data needed
-                  to create am PacketMachine from a template
+                description: PacketMachineTemplateResource describes the data needed to create am PacketMachine from a template
                 properties:
                   spec:
-                    description: Spec is the specification of the desired behavior
-                      of the machine.
+                    description: Spec is the specification of the desired behavior of the machine.
                     properties:
                       OS:
                         type: string
                       billingCycle:
                         type: string
+                      facility:
+                        description: Facility represents the Packet facility for this cluster. Override from the PacketCluster spec.
+                        type: string
                       hardwareReservationID:
-                        description: HardwareReservationID is the unique device hardware
-                          reservation ID or `next-available` to automatically let
-                          the Packet api determine one.
+                        description: HardwareReservationID is the unique device hardware reservation ID or `next-available` to automatically let the Packet api determine one.
                         type: string
                       ipxeURL:
-                        description: IPXEUrl can be used to set the pxe boot url when
-                          using custom OSes with this provider. Note that OS should
-                          also be set to "custom_ipxe" if using this value.
+                        description: IPXEUrl can be used to set the pxe boot url when using custom OSes with this provider. Note that OS should also be set to "custom_ipxe" if using this value.
                         type: string
                       machineType:
                         type: string
                       providerID:
-                        description: ProviderID is the unique identifier as specified
-                          by the cloud provider.
+                        description: ProviderID is the unique identifier as specified by the cloud provider.
                         type: string
                       sshKeys:
                         items:
                           type: string
                         type: array
                       tags:
-                        description: Tags is an optional set of tags to add to Packet
-                          resources managed by the Packet provider.
+                        description: Tags is an optional set of tags to add to Packet resources managed by the Packet provider.
                         items:
                           type: string
                         type: array

--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -1,3 +1,5 @@
+
+---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:

--- a/pkg/cloud/packet/client.go
+++ b/pkg/cloud/packet/client.go
@@ -112,10 +112,16 @@ func (p *PacketClient) NewDevice(req CreateDeviceRequest) (*packngo.Device, erro
 
 	userData = stringWriter.String()
 
+	// Allow to override the facility for each PacketMachineTemplate
+	var facility = req.MachineScope.PacketCluster.Spec.Facility
+	if req.MachineScope.PacketMachine.Spec.Facility != "" {
+		facility = req.MachineScope.PacketMachine.Spec.Facility
+	}
+
 	serverCreateOpts := &packngo.DeviceCreateRequest{
 		Hostname:              req.MachineScope.Name(),
 		ProjectID:             req.MachineScope.PacketCluster.Spec.ProjectID,
-		Facility:              []string{req.MachineScope.PacketCluster.Spec.Facility},
+		Facility:              []string{facility},
 		BillingCycle:          req.MachineScope.PacketMachine.Spec.BillingCycle,
 		HardwareReservationID: req.MachineScope.PacketMachine.Spec.HardwareReservationID,
 		Plan:                  req.MachineScope.PacketMachine.Spec.MachineType,


### PR DESCRIPTION
**What this PR does / why we need it**:

Allows the ability to override the facility per PacketMachineTemplate. Use case would be to launch a MachineDeployment into another datacenter but still be connected to the primary cluster.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #228 
