### PR TITLE
:sparkles: Increase defaults limits/requests for deployment

### DIFF
--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -38,10 +38,10 @@ spec:
         resources:
           limits:
             cpu: 100m
-            memory: 30Mi
+            memory: 50Mi
           requests:
             cpu: 100m
-            memory: 20Mi
+            memory: 35Mi
       terminationGracePeriodSeconds: 10
       tolerations:
       - effect: NoSchedule


### PR DESCRIPTION
**What this PR does / why we need it**:

Increases the default memory requests/limits for the cluster-api-provider-packet deployment

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #233 
