### PR TITLE
:running: Add dependabot config and update go version for testing to v1.15

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,19 @@
+version: 2
+updates:
+  # Maintain dependencies for GitHub Actions.
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "daily"
+
+  # Maintain dependencies for Go modules.
+  - package-ecosystem: "gomod"
+    directory: "/"
+    schedule:
+      interval: "daily"
+
+  # Maintain dependencies for Docker images.
+  - package-ecosystem: "docker"
+    directory: "/"
+    schedule:
+      interval: "daily"

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -26,7 +26,7 @@ jobs:
       uses: actions/checkout@v2
     - uses: actions/setup-go@v2
       with:
-        go-version: '1.14.2' # The Go version to download (if necessary) and use.
+        go-version: '1.15' # The Go version to download (if necessary) and use.
     - name: kubebuilder
       run: make kubebuilder KUBEBUILDER_DIR=${KUBEBUILDER_DIR} # we use this dir because /usr/local/kubebuilder is protected
     - name: test


### PR DESCRIPTION
**What this PR does / why we need it**:

- Adds a dependabot configuration to proactively update dependencies for Go, github workflows, and docker images
- Updates the go version used for CI to v1.15

