### PR TITLE
:running: Update to reflect renaming of master branch to main

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -4,7 +4,7 @@ on:
    types: [opened, synchronize, reopened]
  push:
    branches:
-   - master
+   - main
 
 env:
   KUBEBUILDER_DIR: /tmp/kubebuilder_install
@@ -47,11 +47,11 @@ jobs:
       env:
         KUBEBUILDER_ASSETS: ${{ env.KUBEBUILDER_DIR }}/bin
 
-    # these next steps are used for merge to master (push the images)
+    # these next steps are used for merge to main (push the images)
     # they really should be separate workflows or jobs, but github actions is awful about sharing between them, so it must be one job
     - name: docker login
-      if: github.event_name == 'push' && endsWith(github.ref,'/master')
+      if: github.event_name == 'push' && endsWith(github.ref,'/main')
       run: echo "${{ secrets.DOCKER_PASSWORD }}" | docker login -u "${{ secrets.DOCKER_USERNAME }}" --password-stdin
-    - name: deploy   # when merged into master, tag master and push - ideally, this would be a separate job, but you cannot share docker build cache between jobs
-      if: github.event_name == 'push' && endsWith(github.ref,'/master')
-      run: make cd CONFIRM=true BRANCH_NAME=master
+    - name: deploy   # when merged into main, tag main and push - ideally, this would be a separate job, but you cannot share docker build cache between jobs
+      if: github.event_name == 'push' && endsWith(github.ref,'/main')
+      run: make cd CONFIRM=true BRANCH_NAME=main

--- a/docs/RELEASE.md
+++ b/docs/RELEASE.md
@@ -47,7 +47,7 @@ When the VERSION file changes:
 * CI copies the artifacts in `out/release/infrastructure-packet/<version>/*yaml` to the github releases
 * CI builds docker images for each supported architecture as well as a multi-arch manifest, and tags it with:
   * the git hash of the commit
-  * `master`
+  * `main`
   * the semver tag of the release, e.g. `v0.3.1`
   * the tag `latest`
 


### PR DESCRIPTION
**What this PR does / why we need it**:

Updates the repo to reflect the new default branch of main instead of master

