### PR TITLE
🏃 Remove ncdc from owners

### DIFF
--- a/OWNERS_ALIASES
+++ b/OWNERS_ALIASES
@@ -13,7 +13,6 @@ aliases:
   cluster-api-maintainers:
     - justinsb
     - detiber
-    - ncdc
     - vincepri
   cluster-api-packet-maintainers:
     - deitch


### PR DESCRIPTION
**What this PR does / why we need it**: Remove myself from owners as I am no longer an active Cluster API
maintainer.