### PR TITLE
remove SIG label from OWNERS file

### DIFF
--- a/OWNERS
+++ b/OWNERS
@@ -8,6 +8,3 @@ approvers:
 
 reviewers:
   - cluster-api-packet-maintainers
-
-labels:
-  - sig/cluster-lifecycle


### PR DESCRIPTION
<!-- please add a icon to the title of this PR (see https://sigs.k8s.io/cluster-api/VERSIONING.md), and delete this line and similar ones -->
<!-- the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, minor or feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🏃 (:running:, other) -->

**What this PR does / why we need it**:

subproject or SIG labels are not needed on subproject PRs/issues as they are implied.
helps for better org wide triage on SIG CL tickets, coming from third parties.


**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:

NONE

/kind cleanup
/priority backlog
