### PR TITLE
✨ Add support for kube-vip

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -275,6 +275,7 @@ generate: ## Generate code
 
 .PHONY: generate-templates
 generate-templates: $(KUSTOMIZE) ## Generate cluster templates
+	$(KUSTOMIZE) build templates/experimental-kube-vip --load-restrictor LoadRestrictionsNone > templates/cluster-template-kube-vip.yaml
 	$(KUSTOMIZE) build templates/experimental-crs-cni --load-restrictor LoadRestrictionsNone > templates/cluster-template-crs-cni.yaml
 	$(KUSTOMIZE) build templates/addons/calico > templates/addons/calico.yaml
 

--- a/api/v1alpha3/packetcluster_types.go
+++ b/api/v1alpha3/packetcluster_types.go
@@ -21,6 +21,9 @@ import (
 	clusterv1 "sigs.k8s.io/cluster-api/api/v1alpha3"
 )
 
+// VIPManagerType describes if the VIP will be managed by CPEM or kube-vip
+type VIPManagerType string
+
 // PacketClusterSpec defines the desired state of PacketCluster
 type PacketClusterSpec struct {
 	// ProjectID represents the Packet Project where this cluster will be placed into
@@ -32,6 +35,12 @@ type PacketClusterSpec struct {
 	// ControlPlaneEndpoint represents the endpoint used to communicate with the control plane.
 	// +optional
 	ControlPlaneEndpoint clusterv1.APIEndpoint `json:"controlPlaneEndpoint"`
+
+	// VIPManager represents whether this cluster uses CPEM or kube-vip to
+	// manage its vip for the api server IP
+	// +kubebuilder:validation:Enum=CPEM;KUBE_VIP
+	// +kubebuilder:default:=CPEM
+	VIPManager VIPManagerType `json:"vipManager"`
 }
 
 // PacketClusterStatus defines the observed state of PacketCluster

--- a/api/v1alpha3/zz_generated.conversion.go
+++ b/api/v1alpha3/zz_generated.conversion.go
@@ -241,6 +241,7 @@ func autoConvert_v1alpha3_PacketClusterSpec_To_v1beta1_PacketClusterSpec(in *Pac
 	if err := apiv1alpha3.Convert_v1alpha3_APIEndpoint_To_v1beta1_APIEndpoint(&in.ControlPlaneEndpoint, &out.ControlPlaneEndpoint, s); err != nil {
 		return err
 	}
+	out.VIPManager = v1beta1.VIPManagerType(in.VIPManager)
 	return nil
 }
 
@@ -255,6 +256,7 @@ func autoConvert_v1beta1_PacketClusterSpec_To_v1alpha3_PacketClusterSpec(in *v1b
 	if err := apiv1alpha3.Convert_v1beta1_APIEndpoint_To_v1alpha3_APIEndpoint(&in.ControlPlaneEndpoint, &out.ControlPlaneEndpoint, s); err != nil {
 		return err
 	}
+	out.VIPManager = VIPManagerType(in.VIPManager)
 	return nil
 }
 

--- a/api/v1beta1/packetcluster_types.go
+++ b/api/v1beta1/packetcluster_types.go
@@ -26,6 +26,9 @@ const (
 	NetworkInfrastructureReadyCondition clusterv1.ConditionType = "NetworkInfrastructureReady"
 )
 
+// VIPManagerType describes if the VIP will be managed by CPEM or kube-vip
+type VIPManagerType string
+
 // PacketClusterSpec defines the desired state of PacketCluster
 type PacketClusterSpec struct {
 	// ProjectID represents the Packet Project where this cluster will be placed into
@@ -37,6 +40,12 @@ type PacketClusterSpec struct {
 	// ControlPlaneEndpoint represents the endpoint used to communicate with the control plane.
 	// +optional
 	ControlPlaneEndpoint clusterv1.APIEndpoint `json:"controlPlaneEndpoint"`
+
+	// VIPManager represents whether this cluster uses CPEM or kube-vip to
+	// manage its vip for the api server IP
+	// +kubebuilder:validation:Enum=CPEM;KUBE_VIP
+	// +kubebuilder:default:=CPEM
+	VIPManager VIPManagerType `json:"vipManager"`
 }
 
 // PacketClusterStatus defines the observed state of PacketCluster

--- a/api/v1beta1/packetcluster_webhook.go
+++ b/api/v1beta1/packetcluster_webhook.go
@@ -71,6 +71,13 @@ func (c *PacketCluster) ValidateUpdate(oldRaw runtime.Object) error {
 		)
 	}
 
+	if !reflect.DeepEqual(c.Spec.VIPManager, old.Spec.VIPManager) {
+		allErrs = append(allErrs,
+			field.Invalid(field.NewPath("spec", "VIPManager"),
+				c.Spec.VIPManager, "field is immutable"),
+		)
+	}
+
 	if len(allErrs) == 0 {
 		return nil
 	}

--- a/config/crd/bases/infrastructure.cluster.x-k8s.io_packetclusters.yaml
+++ b/config/crd/bases/infrastructure.cluster.x-k8s.io_packetclusters.yaml
@@ -68,8 +68,17 @@ spec:
                 description: ProjectID represents the Packet Project where this cluster
                   will be placed into
                 type: string
+              vipManager:
+                default: CPEM
+                description: VIPManager represents whether this cluster uses CPEM
+                  or kube-vip to manage its vip for the api server IP
+                enum:
+                - CPEM
+                - KUBE_VIP
+                type: string
             required:
             - projectID
+            - vipManager
             type: object
           status:
             description: PacketClusterStatus defines the observed state of PacketCluster
@@ -134,8 +143,17 @@ spec:
                 description: ProjectID represents the Packet Project where this cluster
                   will be placed into
                 type: string
+              vipManager:
+                default: CPEM
+                description: VIPManager represents whether this cluster uses CPEM
+                  or kube-vip to manage its vip for the api server IP
+                enum:
+                - CPEM
+                - KUBE_VIP
+                type: string
             required:
             - projectID
+            - vipManager
             type: object
           status:
             description: PacketClusterStatus defines the observed state of PacketCluster

--- a/config/default/config.yaml
+++ b/config/default/config.yaml
@@ -1,0 +1,7 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: manager-config
+  namespace: system
+data:
+  EIP_MANAGEMENT: "${EIP_MANAGEMENT:=CPEM}"

--- a/config/default/config.yaml
+++ b/config/default/config.yaml
@@ -1,7 +1,0 @@
-apiVersion: v1
-kind: ConfigMap
-metadata:
-  name: manager-config
-  namespace: system
-data:
-  EIP_MANAGEMENT: "${EIP_MANAGEMENT:=CPEM}"

--- a/config/default/kustomization.yaml
+++ b/config/default/kustomization.yaml
@@ -12,6 +12,7 @@ commonLabels:
 
 resources:
 - namespace.yaml
+- config.yaml
 - credentials.yaml
 
 bases:
@@ -26,7 +27,7 @@ patchesStrategicMerge:
 - manager_pull_policy.yaml
 - manager_webhook_patch.yaml
 - webhookcainjection_patch.yaml
-- manager_credentials_patch.yaml
+- manager_credentials_config_patch.yaml
 
 vars:
   - name: CERTIFICATE_NAMESPACE # namespace of the certificate CR

--- a/config/default/kustomization.yaml
+++ b/config/default/kustomization.yaml
@@ -12,7 +12,6 @@ commonLabels:
 
 resources:
 - namespace.yaml
-- config.yaml
 - credentials.yaml
 
 bases:

--- a/config/default/kustomizeconfig.yaml
+++ b/config/default/kustomizeconfig.yaml
@@ -2,3 +2,5 @@
 varReference:
 - kind: Deployment
   path: spec/template/spec/volumes/secret/secretName
+- kind: Deployment
+  path: spec/template/spec/volumes/configMap/configMapName

--- a/config/default/manager_credentials_config_patch.yaml
+++ b/config/default/manager_credentials_config_patch.yaml
@@ -11,3 +11,5 @@ spec:
         envFrom:
         - secretRef:
             name: manager-api-credentials
+        - configMapRef:
+            name: manager-config

--- a/config/default/manager_credentials_config_patch.yaml
+++ b/config/default/manager_credentials_config_patch.yaml
@@ -11,5 +11,3 @@ spec:
         envFrom:
         - secretRef:
             name: manager-api-credentials
-        - configMapRef:
-            name: manager-config

--- a/controllers/packetcluster_controller.go
+++ b/controllers/packetcluster_controller.go
@@ -137,6 +137,11 @@ func (r *PacketClusterReconciler) reconcileNormal(ctx context.Context, clusterSc
 		}
 	}
 
+	if err := r.PacketClient.EnableProjectBGP(packetCluster.Spec.ProjectID); err != nil {
+		log.Error(err, "error enabling bgp for project")
+		return ctrl.Result{}, err
+	}
+
 	clusterScope.PacketCluster.Status.Ready = true
 	conditions.MarkTrue(packetCluster, infrav1.NetworkInfrastructureReadyCondition)
 

--- a/controllers/packetcluster_controller.go
+++ b/controllers/packetcluster_controller.go
@@ -19,6 +19,7 @@ package controllers
 import (
 	"context"
 	"errors"
+	"os"
 
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	clusterv1 "sigs.k8s.io/cluster-api/api/v1beta1"
@@ -137,9 +138,11 @@ func (r *PacketClusterReconciler) reconcileNormal(ctx context.Context, clusterSc
 		}
 	}
 
-	if err := r.PacketClient.EnableProjectBGP(packetCluster.Spec.ProjectID); err != nil {
-		log.Error(err, "error enabling bgp for project")
-		return ctrl.Result{}, err
+	if os.Getenv("EIP_MANAGEMENT") == "KUBE_VIP" {
+		if err := r.PacketClient.EnableProjectBGP(packetCluster.Spec.ProjectID); err != nil {
+			log.Error(err, "error enabling bgp for project")
+			return ctrl.Result{}, err
+		}
 	}
 
 	clusterScope.PacketCluster.Status.Ready = true

--- a/controllers/packetcluster_controller.go
+++ b/controllers/packetcluster_controller.go
@@ -19,7 +19,6 @@ package controllers
 import (
 	"context"
 	"errors"
-	"os"
 
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	clusterv1 "sigs.k8s.io/cluster-api/api/v1beta1"
@@ -138,7 +137,7 @@ func (r *PacketClusterReconciler) reconcileNormal(ctx context.Context, clusterSc
 		}
 	}
 
-	if os.Getenv("EIP_MANAGEMENT") == "KUBE_VIP" {
+	if clusterScope.PacketCluster.Spec.VIPManager == "KUBE_VIP" {
 		if err := r.PacketClient.EnableProjectBGP(packetCluster.Spec.ProjectID); err != nil {
 			log.Error(err, "error enabling bgp for project")
 			return ctrl.Result{}, err

--- a/controllers/packetmachine_controller.go
+++ b/controllers/packetmachine_controller.go
@@ -223,7 +223,7 @@ func (r *PacketMachineReconciler) PacketClusterToPacketMachines(ctx context.Cont
 	}
 }
 
-func (r *PacketMachineReconciler) reconcile(ctx context.Context, machineScope *scope.MachineScope) (ctrl.Result, error) {
+func (r *PacketMachineReconciler) reconcile(ctx context.Context, machineScope *scope.MachineScope) (ctrl.Result, error) { //nolint:gocyclo
 	log := ctrl.LoggerFrom(ctx, "machine", machineScope.Machine.Name, "cluster", machineScope.Cluster.Name)
 	log.Info("Reconciling PacketMachine")
 
@@ -317,7 +317,7 @@ func (r *PacketMachineReconciler) reconcile(ctx context.Context, machineScope *s
 			ExtraTags:    packet.DefaultCreateTags(machineScope.Namespace(), machineScope.Machine.Name, machineScope.Cluster.Name),
 		}
 
-		// when the node is a control plan we need the elastic IP
+		// when a node is a control plane node we need the elastic IP
 		// to template out the kube-vip deployment
 		if machineScope.IsControlPlane() {
 			controlPlaneEndpoint, _ = r.PacketClient.GetIPByClusterIdentifier(

--- a/controllers/packetmachine_controller.go
+++ b/controllers/packetmachine_controller.go
@@ -222,7 +222,7 @@ func (r *PacketMachineReconciler) PacketClusterToPacketMachines(ctx context.Cont
 	}
 }
 
-func (r *PacketMachineReconciler) reconcile(ctx context.Context, machineScope *scope.MachineScope) (ctrl.Result, error) { //nolint:gocyclo
+func (r *PacketMachineReconciler) reconcile(ctx context.Context, machineScope *scope.MachineScope) (ctrl.Result, error) {
 	log := ctrl.LoggerFrom(ctx, "machine", machineScope.Machine.Name, "cluster", machineScope.Cluster.Name)
 	log.Info("Reconciling PacketMachine")
 
@@ -371,13 +371,6 @@ func (r *PacketMachineReconciler) reconcile(ctx context.Context, machineScope *s
 		result = ctrl.Result{RequeueAfter: 10 * time.Second}
 	case infrav1.PacketResourceStatusRunning:
 		log.Info("Machine instance is active", "instance-id", machineScope.GetInstanceID())
-
-		// This logic is here because an elastic ip is neede to create
-		// the kube-vip template
-		controlPlaneEndpoint, _ = r.PacketClient.GetIPByClusterIdentifier(
-			machineScope.Cluster.Namespace,
-			machineScope.Cluster.Name,
-			machineScope.PacketCluster.Spec.ProjectID)
 		machineScope.SetReady()
 		conditions.MarkTrue(machineScope.PacketMachine, infrav1.DeviceReadyCondition)
 

--- a/controllers/packetmachine_controller.go
+++ b/controllers/packetmachine_controller.go
@@ -21,7 +21,6 @@ import (
 	"errors"
 	"fmt"
 	"net/http"
-	"os"
 	"strings"
 	"time"
 
@@ -324,7 +323,7 @@ func (r *PacketMachineReconciler) reconcile(ctx context.Context, machineScope *s
 				machineScope.Cluster.Namespace,
 				machineScope.Cluster.Name,
 				machineScope.PacketCluster.Spec.ProjectID)
-			if os.Getenv("EIP_MANAGEMENT") == "CPEM" {
+			if machineScope.PacketCluster.Spec.VIPManager == "CPEM" {
 				if len(controlPlaneEndpoint.Assignments) == 0 {
 					a := corev1.NodeAddress{
 						Type:    corev1.NodeExternalIP,
@@ -363,7 +362,7 @@ func (r *PacketMachineReconciler) reconcile(ctx context.Context, machineScope *s
 	machineScope.SetProviderID(dev.ID)
 	machineScope.SetInstanceStatus(infrav1.PacketResourceStatus(dev.State))
 
-	if os.Getenv("EIP_MANAGEMENT") == "KUBE_VIP" {
+	if machineScope.PacketCluster.Spec.VIPManager == "KUBE_VIP" {
 		if err := r.PacketClient.EnsureNodeBGPEnabled(dev.ID); err != nil {
 			// Do not treat an error enabling bgp on machine as fatal
 			return ctrl.Result{RequeueAfter: time.Second * 20}, fmt.Errorf("failed to enable bpg on machine %s: %w", machineScope.Name(), err)
@@ -384,7 +383,7 @@ func (r *PacketMachineReconciler) reconcile(ctx context.Context, machineScope *s
 	case infrav1.PacketResourceStatusRunning:
 		log.Info("Machine instance is active", "instance-id", machineScope.GetInstanceID())
 
-		if os.Getenv("EIP_MANAGEMENT") == "CPEM" {
+		if machineScope.PacketCluster.Spec.VIPManager == "CPEM" {
 			controlPlaneEndpoint, _ = r.PacketClient.GetIPByClusterIdentifier(
 				machineScope.Cluster.Namespace,
 				machineScope.Cluster.Name,

--- a/controllers/packetmachine_controller.go
+++ b/controllers/packetmachine_controller.go
@@ -223,7 +223,7 @@ func (r *PacketMachineReconciler) PacketClusterToPacketMachines(ctx context.Cont
 	}
 }
 
-func (r *PacketMachineReconciler) reconcile(ctx context.Context, machineScope *scope.MachineScope) (ctrl.Result, error) { //nolint:gocyclo
+func (r *PacketMachineReconciler) reconcile(ctx context.Context, machineScope *scope.MachineScope) (ctrl.Result, error) { //nolint:gocyclo,maintidx
 	log := ctrl.LoggerFrom(ctx, "machine", machineScope.Machine.Name, "cluster", machineScope.Cluster.Name)
 	log.Info("Reconciling PacketMachine")
 

--- a/pkg/cloud/packet/client.go
+++ b/pkg/cloud/packet/client.go
@@ -246,7 +246,9 @@ func (p *Client) EnableProjectBGP(projectID string) error {
 	// - bgpConfig struct exists
 	// - bgpConfig struct has non-blank ID
 	// - bgpConfig struct does not have Status=="disabled"
-	if err == nil && bgpConfig != nil && bgpConfig.ID != "" && strings.ToLower(bgpConfig.Status) != "disabled" {
+	if err != nil {
+		return err
+	} else if bgpConfig != nil && bgpConfig.ID != "" && strings.ToLower(bgpConfig.Status) != "disabled" {
 		return nil
 	}
 

--- a/pkg/cloud/packet/client.go
+++ b/pkg/cloud/packet/client.go
@@ -40,7 +40,7 @@ const (
 	clientName      = "CAPP-v1beta1"
 	ipxeOS          = "custom_ipxe"
 	envVarLocalASN  = "METAL_LOCAL_ASN"
-	envVarBGPPass   = "METAL_BGP_PASS"
+	envVarBGPPass   = "METAL_BGP_PASS" //nolint:gosec
 	DefaultLocalASN = 65000
 )
 

--- a/templates/addons/calico.yaml
+++ b/templates/addons/calico.yaml
@@ -2497,7 +2497,7 @@ spec:
           value: node
         - name: DATASTORE_TYPE
           value: kubernetes
-        image: quay.io/calico/kube-controllers:v3.20.4
+        image: quay.io/calico/kube-controllers:v3.20.5
         livenessProbe:
           exec:
             command:
@@ -2603,7 +2603,7 @@ spec:
         - configMapRef:
             name: kubernetes-services-endpoint
             optional: true
-        image: quay.io/calico/node:v3.20.4
+        image: quay.io/calico/node:v3.20.5
         lifecycle:
           preStop:
             exec:
@@ -2677,7 +2677,7 @@ spec:
         - configMapRef:
             name: kubernetes-services-endpoint
             optional: true
-        image: quay.io/calico/cni:v3.20.4
+        image: quay.io/calico/cni:v3.20.5
         name: upgrade-ipam
         securityContext:
           privileged: true
@@ -2711,7 +2711,7 @@ spec:
         - configMapRef:
             name: kubernetes-services-endpoint
             optional: true
-        image: quay.io/calico/cni:v3.20.4
+        image: quay.io/calico/cni:v3.20.5
         name: install-cni
         securityContext:
           privileged: true
@@ -2720,7 +2720,7 @@ spec:
           name: cni-bin-dir
         - mountPath: /host/etc/cni/net.d
           name: cni-net-dir
-      - image: quay.io/calico/pod2daemon-flexvol:v3.20.4
+      - image: quay.io/calico/pod2daemon-flexvol:v3.20.5
         name: flexvol-driver
         securityContext:
           privileged: true

--- a/templates/cluster-template-crs-cni.yaml
+++ b/templates/cluster-template-crs-cni.yaml
@@ -176,6 +176,11 @@ spec:
       TRIMMED_KUBERNETES_VERSION=$(echo {{ .kubernetesVersion }} | sed 's/\./\\\\./g' | sed 's/^v//')
       RESOLVED_KUBERNETES_VERSION=$(apt-cache madison kubelet | awk -v VERSION=$${TRIMMED_KUBERNETES_VERSION} '$3~ VERSION { print $3 }' | head -n1)
       DEBIAN_FRONTEND=noninteractive apt-get install -y containerd kubelet=$${RESOLVED_KUBERNETES_VERSION} kubeadm=$${RESOLVED_KUBERNETES_VERSION} kubectl=$${RESOLVED_KUBERNETES_VERSION}
+      curl -o /run/metadata.json -fsSL https://metadata.platformequinix.com/metadata
+      for i in $(cat /run/metadata.json | jq -r '.bgp_neighbors[0].peer_ips[]'); do
+        ip route add $i via $(cat /run/metadata.json | jq -r '.network.addresses[] | select(.public == false and .address_family == 4) | .gateway')
+      done
+      rm /run/metadata.json
       ping -c 3 -q {{ .controlPlaneEndpoint }} && echo OK || ip addr add {{ .controlPlaneEndpoint }} dev lo
   machineTemplate:
     infrastructureRef:

--- a/templates/cluster-template-crs-cni.yaml
+++ b/templates/cluster-template-crs-cni.yaml
@@ -150,7 +150,7 @@ spec:
       if [ -f "/run/kubeadm/kubeadm.yaml" ]; then
         export KUBECONFIG=/etc/kubernetes/admin.conf
         export CPEM_YAML=https://github.com/equinix/cloud-provider-equinix-metal/releases/download/v3.4.0/deployment.yaml
-        export SECRET_DATA='cloud-sa.json=''{"apiKey": "{{ .apiKey }}","projectID": "${PROJECT_ID}", "loadbalancer": "kube-vip://"}'''
+        export SECRET_DATA='cloud-sa.json=''{"apiKey": "{{ .apiKey }}","projectID": "${PROJECT_ID}", "loadbalancer": "kube-vip://", "facility": "${FACILITY}"}'''
         kubectl create secret generic -n kube-system metal-cloud-config --from-literal="$${SECRET_DATA}" || (sleep 1 && kubectl create secret generic -n kube-system metal-cloud-config --from-literal="$${SECRET_DATA}") || (sleep 1 && kubectl create secret generic -n kube-system metal-cloud-config --from-literal="$${SECRET_DATA}")
         kubectl apply -f $${CPEM_YAML} || (sleep 1 && kubectl apply -f $${CPEM_YAML}) || (sleep 1 && kubectl apply -f $${CPEM_YAML})
       fi

--- a/templates/cluster-template-crs-cni.yaml
+++ b/templates/cluster-template-crs-cni.yaml
@@ -142,9 +142,9 @@ spec:
     postKubeadmCommands:
     - |
       if [ -f "/run/kubeadm/kubeadm-join-config.yaml" ]; then
-        KVVERSION="v0.4.2"
+        KVVERSION="${KUBE_VIP_VERSION:=v0.4.2}"
         ctr image pull ghcr.io/kube-vip/kube-vip:$${KVVERSION}
-        ctr run --rm --net-host ghcr.io/kube-vip/kube-vip:$${KVVERSION} vip /kube-vip manifest pod --interface "lo" --vip "{{ .controlPlaneEndpoint }}" --controlplane --bgp --metal --metalKey "{{ .apiKey }}" --metalProjectID "b264ba74-f3bd-49f0-ae24-b0953765b7aa" | tee  /etc/kubernetes/manifests/kube-vip.yaml
+        ctr run --rm --net-host ghcr.io/kube-vip/kube-vip:$${KVVERSION} vip /kube-vip manifest pod --interface "lo" --vip "{{ .controlPlaneEndpoint }}" --controlplane --bgp --metal --metalKey "{{ .apiKey }}" --metalProjectID "${PROJECT_ID}" | tee  /etc/kubernetes/manifests/kube-vip.yaml
       fi
     - |
       if [ -f "/run/kubeadm/kubeadm.yaml" ]; then
@@ -186,10 +186,10 @@ spec:
     - systemctl start containerd
     - |
       if [ -f "/run/kubeadm/kubeadm.yaml" ]; then
-        KVVERSION="v0.4.2"
+        KVVERSION="${KUBE_VIP_VERSION:=v0.4.2}"
         ctr image pull ghcr.io/kube-vip/kube-vip:$${KVVERSION}
         mkdir -p /etc/kubernetes/manifests/
-        ctr run --rm --net-host ghcr.io/kube-vip/kube-vip:$${KVVERSION} vip /kube-vip manifest pod --interface "lo" --vip "{{ .controlPlaneEndpoint }}" --controlplane --bgp --metal --metalKey "{{ .apiKey }}" --metalProjectID "b264ba74-f3bd-49f0-ae24-b0953765b7aa" | tee  /etc/kubernetes/manifests/kube-vip.yaml
+        ctr run --rm --net-host ghcr.io/kube-vip/kube-vip:$${KVVERSION} vip /kube-vip manifest pod --interface "lo" --vip "{{ .controlPlaneEndpoint }}" --controlplane --bgp --metal --metalKey "{{ .apiKey }}" --metalProjectID  "${PROJECT_ID}" | tee  /etc/kubernetes/manifests/kube-vip.yaml
       fi
   machineTemplate:
     infrastructureRef:

--- a/templates/cluster-template-crs-cni.yaml
+++ b/templates/cluster-template-crs-cni.yaml
@@ -30,35 +30,30 @@ spec:
             cloud-provider: external
             provider-id: equinixmetal://{{ `{{ v1.instance_id }}` }}
       preKubeadmCommands:
-      - sed -ri '/\sswap\s/s/^#?/#/' /etc/fstab
-      - swapoff -a
-      - mount -a
       - |
+        sed -ri '/\sswap\s/s/^#?/#/' /etc/fstab
+        swapoff -a
+        mount -a
         cat <<EOF > /etc/modules-load.d/containerd.conf
         overlay
         br_netfilter
         EOF
-      - modprobe overlay
-      - modprobe br_netfilter
-      - |
+        modprobe overlay
+        modprobe br_netfilter
         cat <<EOF > /etc/sysctl.d/99-kubernetes-cri.conf
         net.bridge.bridge-nf-call-iptables  = 1
         net.ipv4.ip_forward                 = 1
         net.bridge.bridge-nf-call-ip6tables = 1
         EOF
-      - sysctl --system
-      - |
+        sysctl --system
         apt-get -y update
-        DEBIAN_FRONTEND=noninteractive apt-get install -y apt-transport-https curl
+        DEBIAN_FRONTEND=noninteractive apt-get install -y apt-transport-https ca-certificates curl gnupg lsb-release linux-generic jq
         curl -s https://packages.cloud.google.com/apt/doc/apt-key.gpg | apt-key add -
         echo "deb https://apt.kubernetes.io/ kubernetes-xenial main" > /etc/apt/sources.list.d/kubernetes.list
         apt-get update -y
         TRIMMED_KUBERNETES_VERSION=$(echo {{ .kubernetesVersion }} | sed 's/\./\\./g' | sed 's/^v//')
         RESOLVED_KUBERNETES_VERSION=$(apt-cache policy kubelet | awk -v VERSION=$${TRIMMED_KUBERNETES_VERSION} '$1~ VERSION { print $1 }' | head -n1)
-        apt-get install -y ca-certificates socat jq ebtables apt-transport-https cloud-utils prips containerd kubelet=$${RESOLVED_KUBERNETES_VERSION} kubeadm=$${RESOLVED_KUBERNETES_VERSION} kubectl=$${RESOLVED_KUBERNETES_VERSION}
-      - systemctl daemon-reload
-      - systemctl enable containerd
-      - systemctl start containerd
+        DEBIAN_FRONTEND=noninteractive apt-get install -y containerd kubelet=$${RESOLVED_KUBERNETES_VERSION} kubeadm=$${RESOLVED_KUBERNETES_VERSION} kubectl=$${RESOLVED_KUBERNETES_VERSION}
 ---
 apiVersion: cluster.x-k8s.io/v1beta1
 kind: Cluster
@@ -135,17 +130,12 @@ spec:
           provider-id: equinixmetal://{{ `{{ v1.instance_id }}` }}
     joinConfiguration:
       nodeRegistration:
-        ignorePreflightErrors: []
+        ignorePreflightErrors:
+        - DirAvailable--etc-kubernetes-manifests
         kubeletExtraArgs:
           cloud-provider: external
           provider-id: equinixmetal://{{ `{{ v1.instance_id }}` }}
     postKubeadmCommands:
-    - |
-      if [ -f "/run/kubeadm/kubeadm-join-config.yaml" ]; then
-        KVVERSION="${KUBE_VIP_VERSION:=v0.4.2}"
-        ctr image pull ghcr.io/kube-vip/kube-vip:$${KVVERSION}
-        ctr run --rm --net-host ghcr.io/kube-vip/kube-vip:$${KVVERSION} vip /kube-vip manifest pod --interface "lo" --vip "{{ .controlPlaneEndpoint }}" --controlplane --bgp --metal --metalKey "{{ .apiKey }}" --metalProjectID "${PROJECT_ID}" | tee  /etc/kubernetes/manifests/kube-vip.yaml
-      fi
     - |
       if [ -f "/run/kubeadm/kubeadm.yaml" ]; then
         export KUBECONFIG=/etc/kubernetes/admin.conf
@@ -155,42 +145,47 @@ spec:
         kubectl apply -f $${CPEM_YAML} || (sleep 1 && kubectl apply -f $${CPEM_YAML}) || (sleep 1 && kubectl apply -f $${CPEM_YAML})
       fi
     preKubeadmCommands:
-    - sed -ri '/\sswap\s/s/^#?/#/' /etc/fstab
-    - swapoff -a
-    - mount -a
     - |
+      sed -ri '/\sswap\s/s/^#?/#/' /etc/fstab
+      swapoff -a
+      mount -a
       cat <<EOF > /etc/modules-load.d/containerd.conf
       overlay
       br_netfilter
       EOF
-    - modprobe overlay
-    - modprobe br_netfilter
-    - |
+      modprobe overlay
+      modprobe br_netfilter
       cat <<EOF > /etc/sysctl.d/99-kubernetes-cri.conf
       net.bridge.bridge-nf-call-iptables  = 1
       net.ipv4.ip_forward                 = 1
       net.bridge.bridge-nf-call-ip6tables = 1
       EOF
-    - sysctl --system
-    - |
+      sysctl --system
       apt-get -y update
-      DEBIAN_FRONTEND=noninteractive apt-get install -y apt-transport-https curl
+      DEBIAN_FRONTEND=noninteractive apt-get install -y apt-transport-https ca-certificates curl gnupg lsb-release linux-generic jq
       curl -s https://packages.cloud.google.com/apt/doc/apt-key.gpg | apt-key add -
       echo "deb https://apt.kubernetes.io/ kubernetes-xenial main" > /etc/apt/sources.list.d/kubernetes.list
       apt-get update -y
-      TRIMMED_KUBERNETES_VERSION=$(echo {{ .kubernetesVersion }} | sed 's/\./\\./g' | sed 's/^v//')
-      RESOLVED_KUBERNETES_VERSION=$(apt-cache policy kubelet | awk -v VERSION=$${TRIMMED_KUBERNETES_VERSION} '$1~ VERSION { print $1 }' | head -n1)
-      apt-get install -y ca-certificates socat jq ebtables apt-transport-https cloud-utils prips containerd kubelet=$${RESOLVED_KUBERNETES_VERSION} kubeadm=$${RESOLVED_KUBERNETES_VERSION} kubectl=$${RESOLVED_KUBERNETES_VERSION}
-    - systemctl daemon-reload
-    - systemctl enable containerd
-    - systemctl start containerd
-    - |
-      if [ -f "/run/kubeadm/kubeadm.yaml" ]; then
-        KVVERSION="${KUBE_VIP_VERSION:=v0.4.2}"
-        ctr image pull ghcr.io/kube-vip/kube-vip:$${KVVERSION}
-        mkdir -p /etc/kubernetes/manifests/
-        ctr run --rm --net-host ghcr.io/kube-vip/kube-vip:$${KVVERSION} vip /kube-vip manifest pod --interface "lo" --vip "{{ .controlPlaneEndpoint }}" --controlplane --bgp --metal --metalKey "{{ .apiKey }}" --metalProjectID  "${PROJECT_ID}" | tee  /etc/kubernetes/manifests/kube-vip.yaml
-      fi
+      TRIMMED_KUBERNETES_VERSION=$(echo {{ .kubernetesVersion }} | sed 's/\./\\\\./g' | sed 's/^v//')
+      RESOLVED_KUBERNETES_VERSION=$(apt-cache madison kubelet | awk -v VERSION=$${TRIMMED_KUBERNETES_VERSION} '$3~ VERSION { print $3 }' | head -n1)
+      DEBIAN_FRONTEND=noninteractive apt-get install -y containerd kubelet=$${RESOLVED_KUBERNETES_VERSION} kubeadm=$${RESOLVED_KUBERNETES_VERSION} kubectl=$${RESOLVED_KUBERNETES_VERSION}
+      curl -o /run/metadata.json -fsSL https://metadata.platformequinix.com/metadata
+      for i in $(cat /run/metadata.json | jq -r '.bgp_neighbors[0].peer_ips[]'); do
+        ip route add $i via $(cat /run/metadata.json | jq -r '.network.addresses[] | select(.public == false and .address_family == 4) | .gateway')
+      done
+      KVVERSION="${KUBE_VIP_VERSION:=v0.4.2}"
+      ctr image pull ghcr.io/kube-vip/kube-vip:$${KVVERSION}
+      ctr run --rm --net-host ghcr.io/kube-vip/kube-vip:$KVVERSION vip /kube-vip manifest pod \
+      --interface "lo" \
+      --vip "{{ .controlPlaneEndpoint }}" \
+      --controlplane \
+      --services \
+      --bgp \
+      --peerAS $(cat /run/metadata.json | jq -r '.bgp_neighbors[0].peer_as') \
+      --peerAddress $(cat /run/metadata.json | jq -r '.bgp_neighbors[0].peer_ips[0]') \
+      --localAS $(cat /run/metadata.json | jq -r '.bgp_neighbors[0].customer_as') \
+      --bgpRouterID $(cat /run/metadata.json | jq -r '.bgp_neighbors[0].customer_ip') > /etc/kubernetes/manifests/vip.yaml
+      rm /run/metadata.json
   machineTemplate:
     infrastructureRef:
       apiVersion: infrastructure.cluster.x-k8s.io/v1beta1

--- a/templates/cluster-template-crs-cni.yaml
+++ b/templates/cluster-template-crs-cni.yaml
@@ -143,7 +143,6 @@ spec:
         address {{ .controlPlaneEndpoint }}
         netmask 255.255.255.255
       EOF
-      systemctl restart networking
       if [ -f "/run/kubeadm/kubeadm.yaml" ]; then
         export KUBECONFIG=/etc/kubernetes/admin.conf
         export CPEM_YAML=https://github.com/equinix/cloud-provider-equinix-metal/releases/download/v3.4.0/deployment.yaml
@@ -176,11 +175,6 @@ spec:
       TRIMMED_KUBERNETES_VERSION=$(echo {{ .kubernetesVersion }} | sed 's/\./\\\\./g' | sed 's/^v//')
       RESOLVED_KUBERNETES_VERSION=$(apt-cache madison kubelet | awk -v VERSION=$${TRIMMED_KUBERNETES_VERSION} '$3~ VERSION { print $3 }' | head -n1)
       DEBIAN_FRONTEND=noninteractive apt-get install -y containerd kubelet=$${RESOLVED_KUBERNETES_VERSION} kubeadm=$${RESOLVED_KUBERNETES_VERSION} kubectl=$${RESOLVED_KUBERNETES_VERSION}
-      curl -o /run/metadata.json -fsSL https://metadata.platformequinix.com/metadata
-      for i in $(cat /run/metadata.json | jq -r '.bgp_neighbors[0].peer_ips[]'); do
-        ip route add $i via $(cat /run/metadata.json | jq -r '.network.addresses[] | select(.public == false and .address_family == 4) | .gateway')
-      done
-      rm /run/metadata.json
       ping -c 3 -q {{ .controlPlaneEndpoint }} && echo OK || ip addr add {{ .controlPlaneEndpoint }} dev lo
   machineTemplate:
     infrastructureRef:

--- a/templates/cluster-template-crs-cni.yaml
+++ b/templates/cluster-template-crs-cni.yaml
@@ -47,14 +47,15 @@ spec:
         net.bridge.bridge-nf-call-ip6tables = 1
         EOF
       - sysctl --system
-      - apt-get -y update
-      - DEBIAN_FRONTEND=noninteractive apt-get install -y apt-transport-https curl
-      - curl -s https://packages.cloud.google.com/apt/doc/apt-key.gpg | apt-key add -
-      - echo "deb https://apt.kubernetes.io/ kubernetes-xenial main" > /etc/apt/sources.list.d/kubernetes.list
-      - apt-get update -y
-      - TRIMMED_KUBERNETES_VERSION=$(echo {{ .kubernetesVersion }} | sed 's/\./\\./g' | sed 's/^v//')
-      - RESOLVED_KUBERNETES_VERSION=$(apt-cache policy kubelet | awk -v VERSION=$${TRIMMED_KUBERNETES_VERSION} '$1~ VERSION { print $1 }' | head -n1)
-      - apt-get install -y ca-certificates socat jq ebtables apt-transport-https cloud-utils prips containerd kubelet=$${RESOLVED_KUBERNETES_VERSION} kubeadm=$${RESOLVED_KUBERNETES_VERSION} kubectl=$${RESOLVED_KUBERNETES_VERSION}
+      - |
+        apt-get -y update
+        DEBIAN_FRONTEND=noninteractive apt-get install -y apt-transport-https curl
+        curl -s https://packages.cloud.google.com/apt/doc/apt-key.gpg | apt-key add -
+        echo "deb https://apt.kubernetes.io/ kubernetes-xenial main" > /etc/apt/sources.list.d/kubernetes.list
+        apt-get update -y
+        TRIMMED_KUBERNETES_VERSION=$(echo {{ .kubernetesVersion }} | sed 's/\./\\./g' | sed 's/^v//')
+        RESOLVED_KUBERNETES_VERSION=$(apt-cache policy kubelet | awk -v VERSION=$${TRIMMED_KUBERNETES_VERSION} '$1~ VERSION { print $1 }' | head -n1)
+        apt-get install -y ca-certificates socat jq ebtables apt-transport-https cloud-utils prips containerd kubelet=$${RESOLVED_KUBERNETES_VERSION} kubeadm=$${RESOLVED_KUBERNETES_VERSION} kubectl=$${RESOLVED_KUBERNETES_VERSION}
       - systemctl daemon-reload
       - systemctl enable containerd
       - systemctl start containerd
@@ -140,15 +141,18 @@ spec:
           provider-id: equinixmetal://{{ `{{ v1.instance_id }}` }}
     postKubeadmCommands:
     - |
+      if [ -f "/run/kubeadm/kubeadm-join-config.yaml" ]; then
+        KVVERSION=$(curl -sL https://api.github.com/repos/kube-vip/kube-vip/releases | jq -r ".[0].name")
+        ctr image pull ghcr.io/kube-vip/kube-vip:$${KVVERSION}
+        ctr run --rm --net-host ghcr.io/kube-vip/kube-vip:$${KVVERSION} vip /kube-vip manifest pod --interface "lo" --vip "{{ .controlPlaneEndpoint }}" --controlplane --bgp --metal --metalKey "{{ .apiKey }}" --metalProjectID "b264ba74-f3bd-49f0-ae24-b0953765b7aa" | tee  /etc/kubernetes/manifests/kube-vip.yaml
+      fi
+    - |
       if [ -f "/run/kubeadm/kubeadm.yaml" ]; then
         export KUBECONFIG=/etc/kubernetes/admin.conf
         export CPEM_YAML=https://github.com/equinix/cloud-provider-equinix-metal/releases/download/v3.4.0/deployment.yaml
         export SECRET_DATA='cloud-sa.json=''{"apiKey": "{{ .apiKey }}","projectID": "${PROJECT_ID}", "eipTag": "cluster-api-provider-packet:cluster-id:${CLUSTER_NAME}", "eipHealthCheckUseHostIP": true}'''
         kubectl create secret generic -n kube-system metal-cloud-config --from-literal="$${SECRET_DATA}" || (sleep 1 && kubectl create secret generic -n kube-system metal-cloud-config --from-literal="$${SECRET_DATA}") || (sleep 1 && kubectl create secret generic -n kube-system metal-cloud-config --from-literal="$${SECRET_DATA}")
         kubectl apply -f $${CPEM_YAML} || (sleep 1 && kubectl apply -f $${CPEM_YAML}) || (sleep 1 && kubectl apply -f $${CPEM_YAML})
-        curl https://gist.githubusercontent.com/DavidSpek/5fbfc8b66ccbf36b47b2ca292965e7bc/raw/a395f146a08592c4f687dd8d471c61c966c1ab7d/kube-vip-control-plane.yaml --output kube-vip-control-plane.yaml
-        sed -i 's/$${LB_ADDRESS}/"{{ .controlPlaneEndpoint }}"/g' kube-vip-control-plane.yaml
-        kubectl apply -f kube-vip-control-plane.yaml || (sleep 1 && kubectl apply -f kube-vip-control-plane.yaml) || (sleep 1 && kubectl apply -f kube-vip-control-plane.yaml)
       fi
     preKubeadmCommands:
     - sed -ri '/\sswap\s/s/^#?/#/' /etc/fstab
@@ -168,17 +172,25 @@ spec:
       net.bridge.bridge-nf-call-ip6tables = 1
       EOF
     - sysctl --system
-    - apt-get -y update
-    - DEBIAN_FRONTEND=noninteractive apt-get install -y apt-transport-https curl
-    - curl -s https://packages.cloud.google.com/apt/doc/apt-key.gpg | apt-key add -
-    - echo "deb https://apt.kubernetes.io/ kubernetes-xenial main" > /etc/apt/sources.list.d/kubernetes.list
-    - apt-get update -y
-    - TRIMMED_KUBERNETES_VERSION=$(echo {{ .kubernetesVersion }} | sed 's/\./\\./g' | sed 's/^v//')
-    - RESOLVED_KUBERNETES_VERSION=$(apt-cache policy kubelet | awk -v VERSION=$${TRIMMED_KUBERNETES_VERSION} '$1~ VERSION { print $1 }' | head -n1)
-    - apt-get install -y ca-certificates socat jq ebtables apt-transport-https cloud-utils prips containerd kubelet=$${RESOLVED_KUBERNETES_VERSION} kubeadm=$${RESOLVED_KUBERNETES_VERSION} kubectl=$${RESOLVED_KUBERNETES_VERSION}
+    - |
+      apt-get -y update
+      DEBIAN_FRONTEND=noninteractive apt-get install -y apt-transport-https curl
+      curl -s https://packages.cloud.google.com/apt/doc/apt-key.gpg | apt-key add -
+      echo "deb https://apt.kubernetes.io/ kubernetes-xenial main" > /etc/apt/sources.list.d/kubernetes.list
+      apt-get update -y
+      TRIMMED_KUBERNETES_VERSION=$(echo {{ .kubernetesVersion }} | sed 's/\./\\./g' | sed 's/^v//')
+      RESOLVED_KUBERNETES_VERSION=$(apt-cache policy kubelet | awk -v VERSION=$${TRIMMED_KUBERNETES_VERSION} '$1~ VERSION { print $1 }' | head -n1)
+      apt-get install -y ca-certificates socat jq ebtables apt-transport-https cloud-utils prips containerd kubelet=$${RESOLVED_KUBERNETES_VERSION} kubeadm=$${RESOLVED_KUBERNETES_VERSION} kubectl=$${RESOLVED_KUBERNETES_VERSION}
     - systemctl daemon-reload
     - systemctl enable containerd
     - systemctl start containerd
+    - |
+      if [ -f "/run/kubeadm/kubeadm.yaml" ]; then
+        KVVERSION=$(curl -sL https://api.github.com/repos/kube-vip/kube-vip/releases | jq -r ".[0].name")
+        ctr image pull ghcr.io/kube-vip/kube-vip:$${KVVERSION}
+        mkdir -p /etc/kubernetes/manifests/
+        ctr run --rm --net-host ghcr.io/kube-vip/kube-vip:$${KVVERSION} vip /kube-vip manifest pod --interface "lo" --vip "{{ .controlPlaneEndpoint }}" --controlplane --bgp --metal --metalKey "{{ .apiKey }}" --metalProjectID "b264ba74-f3bd-49f0-ae24-b0953765b7aa" | tee  /etc/kubernetes/manifests/kube-vip.yaml
+      fi
   machineTemplate:
     infrastructureRef:
       apiVersion: infrastructure.cluster.x-k8s.io/v1beta1

--- a/templates/cluster-template-crs-cni.yaml
+++ b/templates/cluster-template-crs-cni.yaml
@@ -191,6 +191,7 @@ metadata:
 spec:
   facility: ${FACILITY}
   projectID: ${PROJECT_ID}
+  vipManager: CPEM
 ---
 apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
 kind: PacketMachineTemplate

--- a/templates/cluster-template-crs-cni.yaml
+++ b/templates/cluster-template-crs-cni.yaml
@@ -142,7 +142,7 @@ spec:
     postKubeadmCommands:
     - |
       if [ -f "/run/kubeadm/kubeadm-join-config.yaml" ]; then
-        KVVERSION=$(curl -sL https://api.github.com/repos/kube-vip/kube-vip/releases | jq -r ".[0].name")
+        KVVERSION="v0.4.2"
         ctr image pull ghcr.io/kube-vip/kube-vip:$${KVVERSION}
         ctr run --rm --net-host ghcr.io/kube-vip/kube-vip:$${KVVERSION} vip /kube-vip manifest pod --interface "lo" --vip "{{ .controlPlaneEndpoint }}" --controlplane --bgp --metal --metalKey "{{ .apiKey }}" --metalProjectID "b264ba74-f3bd-49f0-ae24-b0953765b7aa" | tee  /etc/kubernetes/manifests/kube-vip.yaml
       fi
@@ -186,7 +186,7 @@ spec:
     - systemctl start containerd
     - |
       if [ -f "/run/kubeadm/kubeadm.yaml" ]; then
-        KVVERSION=$(curl -sL https://api.github.com/repos/kube-vip/kube-vip/releases | jq -r ".[0].name")
+        KVVERSION="v0.4.2"
         ctr image pull ghcr.io/kube-vip/kube-vip:$${KVVERSION}
         mkdir -p /etc/kubernetes/manifests/
         ctr run --rm --net-host ghcr.io/kube-vip/kube-vip:$${KVVERSION} vip /kube-vip manifest pod --interface "lo" --vip "{{ .controlPlaneEndpoint }}" --controlplane --bgp --metal --metalKey "{{ .apiKey }}" --metalProjectID "b264ba74-f3bd-49f0-ae24-b0953765b7aa" | tee  /etc/kubernetes/manifests/kube-vip.yaml

--- a/templates/cluster-template-crs-cni.yaml
+++ b/templates/cluster-template-crs-cni.yaml
@@ -51,7 +51,7 @@ spec:
         curl -s https://packages.cloud.google.com/apt/doc/apt-key.gpg | apt-key add -
         echo "deb https://apt.kubernetes.io/ kubernetes-xenial main" > /etc/apt/sources.list.d/kubernetes.list
         apt-get update -y
-        TRIMMED_KUBERNETES_VERSION=$(echo {{ .kubernetesVersion }} | sed 's/\./\\./g' | sed 's/^v//')
+        TRIMMED_KUBERNETES_VERSION=$(echo {{ .kubernetesVersion }} | sed 's/\./\\\\./g' | sed 's/^v//')
         RESOLVED_KUBERNETES_VERSION=$(apt-cache policy kubelet | awk -v VERSION=$${TRIMMED_KUBERNETES_VERSION} '$1~ VERSION { print $1 }' | head -n1)
         DEBIAN_FRONTEND=noninteractive apt-get install -y containerd kubelet=$${RESOLVED_KUBERNETES_VERSION} kubeadm=$${RESOLVED_KUBERNETES_VERSION} kubectl=$${RESOLVED_KUBERNETES_VERSION}
 ---
@@ -130,17 +130,23 @@ spec:
           provider-id: equinixmetal://{{ `{{ v1.instance_id }}` }}
     joinConfiguration:
       nodeRegistration:
-        ignorePreflightErrors:
-        - DirAvailable--etc-kubernetes-manifests
+        ignorePreflightErrors: []
         kubeletExtraArgs:
           cloud-provider: external
           provider-id: equinixmetal://{{ `{{ v1.instance_id }}` }}
     postKubeadmCommands:
     - |
+      cat <<EOF >> /etc/network/interfaces
+      auto lo:0
+      iface lo:0 inet static
+        address {{ .controlPlaneEndpoint }}
+        netmask 255.255.255.255
+      EOF
+      systemctl restart networking
       if [ -f "/run/kubeadm/kubeadm.yaml" ]; then
         export KUBECONFIG=/etc/kubernetes/admin.conf
         export CPEM_YAML=https://github.com/equinix/cloud-provider-equinix-metal/releases/download/v3.4.0/deployment.yaml
-        export SECRET_DATA='cloud-sa.json=''{"apiKey": "{{ .apiKey }}","projectID": "${PROJECT_ID}", "loadbalancer": "kube-vip://", "facility": "${FACILITY}"}'''
+        export SECRET_DATA='cloud-sa.json=''{"apiKey": "{{ .apiKey }}","projectID": "${PROJECT_ID}", "eipTag": "cluster-api-provider-packet:cluster-id:${CLUSTER_NAME}", "eipHealthCheckUseHostIP": true}'''
         kubectl create secret generic -n kube-system metal-cloud-config --from-literal="$${SECRET_DATA}" || (sleep 1 && kubectl create secret generic -n kube-system metal-cloud-config --from-literal="$${SECRET_DATA}") || (sleep 1 && kubectl create secret generic -n kube-system metal-cloud-config --from-literal="$${SECRET_DATA}")
         kubectl apply -f $${CPEM_YAML} || (sleep 1 && kubectl apply -f $${CPEM_YAML}) || (sleep 1 && kubectl apply -f $${CPEM_YAML})
       fi
@@ -169,23 +175,7 @@ spec:
       TRIMMED_KUBERNETES_VERSION=$(echo {{ .kubernetesVersion }} | sed 's/\./\\\\./g' | sed 's/^v//')
       RESOLVED_KUBERNETES_VERSION=$(apt-cache madison kubelet | awk -v VERSION=$${TRIMMED_KUBERNETES_VERSION} '$3~ VERSION { print $3 }' | head -n1)
       DEBIAN_FRONTEND=noninteractive apt-get install -y containerd kubelet=$${RESOLVED_KUBERNETES_VERSION} kubeadm=$${RESOLVED_KUBERNETES_VERSION} kubectl=$${RESOLVED_KUBERNETES_VERSION}
-      curl -o /run/metadata.json -fsSL https://metadata.platformequinix.com/metadata
-      for i in $(cat /run/metadata.json | jq -r '.bgp_neighbors[0].peer_ips[]'); do
-        ip route add $i via $(cat /run/metadata.json | jq -r '.network.addresses[] | select(.public == false and .address_family == 4) | .gateway')
-      done
-      KVVERSION="${KUBE_VIP_VERSION:=v0.4.2}"
-      ctr image pull ghcr.io/kube-vip/kube-vip:$${KVVERSION}
-      ctr run --rm --net-host ghcr.io/kube-vip/kube-vip:$KVVERSION vip /kube-vip manifest pod \
-      --interface "lo" \
-      --vip "{{ .controlPlaneEndpoint }}" \
-      --controlplane \
-      --services \
-      --bgp \
-      --peerAS $(cat /run/metadata.json | jq -r '.bgp_neighbors[0].peer_as') \
-      --peerAddress $(cat /run/metadata.json | jq -r '.bgp_neighbors[0].peer_ips[0]') \
-      --localAS $(cat /run/metadata.json | jq -r '.bgp_neighbors[0].customer_as') \
-      --bgpRouterID $(cat /run/metadata.json | jq -r '.bgp_neighbors[0].customer_ip') > /etc/kubernetes/manifests/vip.yaml
-      rm /run/metadata.json
+      ping -c 3 -q {{ .controlPlaneEndpoint }} && echo OK || ip addr add {{ .controlPlaneEndpoint }} dev lo
   machineTemplate:
     infrastructureRef:
       apiVersion: infrastructure.cluster.x-k8s.io/v1beta1

--- a/templates/cluster-template-crs-cni.yaml
+++ b/templates/cluster-template-crs-cni.yaml
@@ -140,20 +140,15 @@ spec:
           provider-id: equinixmetal://{{ `{{ v1.instance_id }}` }}
     postKubeadmCommands:
     - |
-      cat <<EOF >> /etc/network/interfaces
-      auto lo:0
-      iface lo:0 inet static
-        address {{ .controlPlaneEndpoint }}
-        netmask 255.255.255.255
-      EOF
-    - systemctl restart networking
-    - |
       if [ -f "/run/kubeadm/kubeadm.yaml" ]; then
         export KUBECONFIG=/etc/kubernetes/admin.conf
         export CPEM_YAML=https://github.com/equinix/cloud-provider-equinix-metal/releases/download/v3.4.0/deployment.yaml
         export SECRET_DATA='cloud-sa.json=''{"apiKey": "{{ .apiKey }}","projectID": "${PROJECT_ID}", "eipTag": "cluster-api-provider-packet:cluster-id:${CLUSTER_NAME}", "eipHealthCheckUseHostIP": true}'''
         kubectl create secret generic -n kube-system metal-cloud-config --from-literal="$${SECRET_DATA}" || (sleep 1 && kubectl create secret generic -n kube-system metal-cloud-config --from-literal="$${SECRET_DATA}") || (sleep 1 && kubectl create secret generic -n kube-system metal-cloud-config --from-literal="$${SECRET_DATA}")
         kubectl apply -f $${CPEM_YAML} || (sleep 1 && kubectl apply -f $${CPEM_YAML}) || (sleep 1 && kubectl apply -f $${CPEM_YAML})
+        curl https://gist.githubusercontent.com/DavidSpek/5fbfc8b66ccbf36b47b2ca292965e7bc/raw/a395f146a08592c4f687dd8d471c61c966c1ab7d/kube-vip-control-plane.yaml --output kube-vip-control-plane.yaml
+        sed -i 's/$${LB_ADDRESS}/"{{ .controlPlaneEndpoint }}"/g' kube-vip-control-plane.yaml
+        kubectl apply -f kube-vip-control-plane.yaml || (sleep 1 && kubectl apply -f kube-vip-control-plane.yaml) || (sleep 1 && kubectl apply -f kube-vip-control-plane.yaml)
       fi
     preKubeadmCommands:
     - sed -ri '/\sswap\s/s/^#?/#/' /etc/fstab
@@ -184,7 +179,6 @@ spec:
     - systemctl daemon-reload
     - systemctl enable containerd
     - systemctl start containerd
-    - ping -c 3 -q {{ .controlPlaneEndpoint }} && echo OK || ip addr add {{ .controlPlaneEndpoint }} dev lo
   machineTemplate:
     infrastructureRef:
       apiVersion: infrastructure.cluster.x-k8s.io/v1beta1

--- a/templates/cluster-template-crs-cni.yaml
+++ b/templates/cluster-template-crs-cni.yaml
@@ -130,7 +130,8 @@ spec:
           provider-id: equinixmetal://{{ `{{ v1.instance_id }}` }}
     joinConfiguration:
       nodeRegistration:
-        ignorePreflightErrors: []
+        ignorePreflightErrors:
+        - DirAvailable--etc-kubernetes-manifests
         kubeletExtraArgs:
           cloud-provider: external
           provider-id: equinixmetal://{{ `{{ v1.instance_id }}` }}

--- a/templates/cluster-template-crs-cni.yaml
+++ b/templates/cluster-template-crs-cni.yaml
@@ -150,7 +150,7 @@ spec:
       if [ -f "/run/kubeadm/kubeadm.yaml" ]; then
         export KUBECONFIG=/etc/kubernetes/admin.conf
         export CPEM_YAML=https://github.com/equinix/cloud-provider-equinix-metal/releases/download/v3.4.0/deployment.yaml
-        export SECRET_DATA='cloud-sa.json=''{"apiKey": "{{ .apiKey }}","projectID": "${PROJECT_ID}", "eipTag": "cluster-api-provider-packet:cluster-id:${CLUSTER_NAME}", "eipHealthCheckUseHostIP": true}'''
+        export SECRET_DATA='cloud-sa.json=''{"apiKey": "{{ .apiKey }}","projectID": "${PROJECT_ID}", "loadbalancer": "kube-vip://"}'''
         kubectl create secret generic -n kube-system metal-cloud-config --from-literal="$${SECRET_DATA}" || (sleep 1 && kubectl create secret generic -n kube-system metal-cloud-config --from-literal="$${SECRET_DATA}") || (sleep 1 && kubectl create secret generic -n kube-system metal-cloud-config --from-literal="$${SECRET_DATA}")
         kubectl apply -f $${CPEM_YAML} || (sleep 1 && kubectl apply -f $${CPEM_YAML}) || (sleep 1 && kubectl apply -f $${CPEM_YAML})
       fi

--- a/templates/cluster-template-kube-vip.yaml
+++ b/templates/cluster-template-kube-vip.yaml
@@ -1,0 +1,210 @@
+kind: KubeadmControlPlane
+apiVersion: controlplane.cluster.x-k8s.io/v1beta1
+metadata:
+  name: "${CLUSTER_NAME}-control-plane"
+spec:
+  version: ${KUBERNETES_VERSION}
+  replicas: ${CONTROL_PLANE_MACHINE_COUNT}
+  machineTemplate:
+    infrastructureRef:
+      apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+      kind: PacketMachineTemplate
+      name: "${CLUSTER_NAME}-control-plane"
+  kubeadmConfigSpec:
+    clusterConfiguration:
+      apiServer:
+          extraArgs:
+              cloud-provider: external
+      controllerManager:
+          extraArgs:
+              cloud-provider: external
+    initConfiguration:
+      nodeRegistration:
+        kubeletExtraArgs:
+          cloud-provider: external
+          provider-id: "equinixmetal://{{ `{{ v1.instance_id }}` }}"
+    joinConfiguration:
+      nodeRegistration:
+        ignorePreflightErrors:
+        - DirAvailable--etc-kubernetes-manifests
+        kubeletExtraArgs:
+          cloud-provider: external
+          provider-id: "equinixmetal://{{ `{{ v1.instance_id }}` }}"
+    preKubeadmCommands:
+      - |
+        sed -ri '/\sswap\s/s/^#?/#/' /etc/fstab
+        swapoff -a
+        mount -a
+        cat <<EOF > /etc/modules-load.d/containerd.conf
+        overlay
+        br_netfilter
+        EOF
+        modprobe overlay
+        modprobe br_netfilter
+        cat <<EOF > /etc/sysctl.d/99-kubernetes-cri.conf
+        net.bridge.bridge-nf-call-iptables  = 1
+        net.ipv4.ip_forward                 = 1
+        net.bridge.bridge-nf-call-ip6tables = 1
+        EOF
+        sysctl --system
+        apt-get -y update
+        DEBIAN_FRONTEND=noninteractive apt-get install -y apt-transport-https ca-certificates curl gnupg lsb-release linux-generic jq
+        curl -s https://packages.cloud.google.com/apt/doc/apt-key.gpg | apt-key add -
+        echo "deb https://apt.kubernetes.io/ kubernetes-xenial main" > /etc/apt/sources.list.d/kubernetes.list
+        apt-get update -y
+        TRIMMED_KUBERNETES_VERSION=$(echo {{ .kubernetesVersion }} | sed 's/\./\\\\./g' | sed 's/^v//')
+        RESOLVED_KUBERNETES_VERSION=$(apt-cache madison kubelet | awk -v VERSION=$${TRIMMED_KUBERNETES_VERSION} '$3~ VERSION { print $3 }' | head -n1)
+        DEBIAN_FRONTEND=noninteractive apt-get install -y containerd kubelet=$${RESOLVED_KUBERNETES_VERSION} kubeadm=$${RESOLVED_KUBERNETES_VERSION} kubectl=$${RESOLVED_KUBERNETES_VERSION}
+        curl -o /run/metadata.json -fsSL https://metadata.platformequinix.com/metadata
+        for i in $(cat /run/metadata.json | jq -r '.bgp_neighbors[0].peer_ips[]'); do
+          ip route add $i via $(cat /run/metadata.json | jq -r '.network.addresses[] | select(.public == false and .address_family == 4) | .gateway')
+        done
+        KVVERSION="${KUBE_VIP_VERSION:=v0.4.2}"
+        ctr image pull ghcr.io/kube-vip/kube-vip:$${KVVERSION}
+        ctr run --rm --net-host ghcr.io/kube-vip/kube-vip:$KVVERSION vip /kube-vip manifest pod \
+        --interface "lo" \
+        --vip "{{ .controlPlaneEndpoint }}" \
+        --controlplane \
+        --services \
+        --bgp \
+        --peerAS $(cat /run/metadata.json | jq -r '.bgp_neighbors[0].peer_as') \
+        --peerAddress $(cat /run/metadata.json | jq -r '.bgp_neighbors[0].peer_ips[0]') \
+        --localAS $(cat /run/metadata.json | jq -r '.bgp_neighbors[0].customer_as') \
+        --bgpRouterID $(cat /run/metadata.json | jq -r '.bgp_neighbors[0].customer_ip') > /etc/kubernetes/manifests/vip.yaml
+        rm /run/metadata.json
+    postKubeadmCommands:
+      - |
+        if [ -f "/run/kubeadm/kubeadm.yaml" ]; then
+          export KUBECONFIG=/etc/kubernetes/admin.conf
+          export CPEM_YAML=https://raw.githubusercontent.com/detiber/packet-ccm/test/deploy/template/deployment.yaml
+          export SECRET_DATA='cloud-sa.json=''{"apiKey": "{{ .apiKey }}","projectID": "${PROJECT_ID}", "loadbalancer": "kube-vip://", "facility": "${FACILITY}"}'''
+          kubectl create secret generic -n kube-system metal-cloud-config --from-literal="$${SECRET_DATA}" || (sleep 1 && kubectl create secret generic -n kube-system metal-cloud-config --from-literal="$${SECRET_DATA}") || (sleep 1 && kubectl create secret generic -n kube-system metal-cloud-config --from-literal="$${SECRET_DATA}")
+          kubectl apply -f $${CPEM_YAML} || (sleep 1 && kubectl apply -f $${CPEM_YAML}) || (sleep 1 && kubectl apply -f $${CPEM_YAML})
+        fi
+---
+apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+kind: PacketMachineTemplate
+metadata:
+  name: "${CLUSTER_NAME}-control-plane"
+spec:
+  template:
+    spec:
+      os: "${NODE_OS:=ubuntu_18_04}"
+      billingCycle: hourly
+      machineType: "${CONTROLPLANE_NODE_TYPE}"
+      sshKeys:
+        - "${SSH_KEY}"
+      tags: []
+---
+apiVersion: cluster.x-k8s.io/v1beta1
+kind: Cluster
+metadata:
+  name: "${CLUSTER_NAME}"
+spec:
+  clusterNetwork:
+    pods:
+      cidrBlocks:
+        - ${POD_CIDR:=192.168.0.0/16}
+    services:
+      cidrBlocks:
+        - ${SERVICE_CIDR:=172.26.0.0/16}
+  infrastructureRef:
+    apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+    kind: PacketCluster
+    name: "${CLUSTER_NAME}"
+  controlPlaneRef:
+    apiVersion: controlplane.cluster.x-k8s.io/v1beta1
+    kind: KubeadmControlPlane
+    name: "${CLUSTER_NAME}-control-plane"
+---
+apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+kind: PacketCluster
+metadata:
+  name: "${CLUSTER_NAME}"
+spec:
+  projectID: "${PROJECT_ID}"
+  facility: "${FACILITY}"
+---
+apiVersion: cluster.x-k8s.io/v1beta1
+kind: MachineDeployment
+metadata:
+  name: ${CLUSTER_NAME}-worker-a
+  labels:
+    cluster.x-k8s.io/cluster-name: ${CLUSTER_NAME}
+    pool: worker-a
+spec:
+  replicas: ${WORKER_MACHINE_COUNT}
+  clusterName: ${CLUSTER_NAME}
+  selector:
+    matchLabels:
+      cluster.x-k8s.io/cluster-name: ${CLUSTER_NAME}
+      pool: worker-a
+  template:
+    metadata:
+      labels:
+        cluster.x-k8s.io/cluster-name: ${CLUSTER_NAME}
+        pool: worker-a
+    spec:
+      version: ${KUBERNETES_VERSION}
+      clusterName: ${CLUSTER_NAME}
+      bootstrap:
+        configRef:
+          name: ${CLUSTER_NAME}-worker-a
+          apiVersion: bootstrap.cluster.x-k8s.io/v1beta1
+          kind: KubeadmConfigTemplate
+      infrastructureRef:
+        name: ${CLUSTER_NAME}-worker-a
+        apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+        kind: PacketMachineTemplate
+---
+apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+kind: PacketMachineTemplate
+metadata:
+  name: ${CLUSTER_NAME}-worker-a
+spec:
+  template:
+    spec:
+      os: "${NODE_OS:=ubuntu_18_04}"
+      billingCycle: hourly
+      machineType: "${WORKER_NODE_TYPE}"
+      sshKeys:
+        - "${SSH_KEY}"
+      tags: []
+---
+kind: KubeadmConfigTemplate
+apiVersion: bootstrap.cluster.x-k8s.io/v1beta1
+metadata:
+  name: "${CLUSTER_NAME}-worker-a"
+spec:
+  template:
+    spec:
+      joinConfiguration:
+        nodeRegistration:
+          kubeletExtraArgs:
+            cloud-provider: external
+            provider-id: "equinixmetal://{{ `{{ v1.instance_id }}` }}"
+      preKubeadmCommands:
+        - |
+          sed -ri '/\sswap\s/s/^#?/#/' /etc/fstab
+          swapoff -a
+          mount -a
+          cat <<EOF > /etc/modules-load.d/containerd.conf
+          overlay
+          br_netfilter
+          EOF
+          modprobe overlay
+          modprobe br_netfilter
+          cat <<EOF > /etc/sysctl.d/99-kubernetes-cri.conf
+          net.bridge.bridge-nf-call-iptables  = 1
+          net.ipv4.ip_forward                 = 1
+          net.bridge.bridge-nf-call-ip6tables = 1
+          EOF
+          sysctl --system
+          apt-get -y update
+          DEBIAN_FRONTEND=noninteractive apt-get install -y apt-transport-https ca-certificates curl gnupg lsb-release linux-generic jq
+          curl -s https://packages.cloud.google.com/apt/doc/apt-key.gpg | apt-key add -
+          echo "deb https://apt.kubernetes.io/ kubernetes-xenial main" > /etc/apt/sources.list.d/kubernetes.list
+          apt-get update -y
+          TRIMMED_KUBERNETES_VERSION=$(echo {{ .kubernetesVersion }} | sed 's/\./\\\\./g' | sed 's/^v//')
+          RESOLVED_KUBERNETES_VERSION=$(apt-cache madison kubelet | awk -v VERSION=$${TRIMMED_KUBERNETES_VERSION} '$3~ VERSION { print $3 }' | head -n1)
+          DEBIAN_FRONTEND=noninteractive apt-get install -y containerd kubelet=$${RESOLVED_KUBERNETES_VERSION} kubeadm=$${RESOLVED_KUBERNETES_VERSION} kubectl=$${RESOLVED_KUBERNETES_VERSION}

--- a/templates/cluster-template-kube-vip.yaml
+++ b/templates/cluster-template-kube-vip.yaml
@@ -181,6 +181,7 @@ metadata:
 spec:
   facility: ${FACILITY}
   projectID: ${PROJECT_ID}
+  vipManager: KUBE_VIP
 ---
 apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
 kind: PacketMachineTemplate

--- a/templates/cluster-template-kube-vip.yaml
+++ b/templates/cluster-template-kube-vip.yaml
@@ -120,7 +120,7 @@ spec:
     - |-
       if [ -f "/run/kubeadm/kubeadm.yaml" ]; then
         export KUBECONFIG=/etc/kubernetes/admin.conf
-        export CPEM_YAML=https://raw.githubusercontent.com/detiber/packet-ccm/test/deploy/template/deployment.yaml
+        export CPEM_YAML=https://github.com/equinix/cloud-provider-equinix-metal/releases/download/v3.4.0/deployment.yaml
         export SECRET_DATA='cloud-sa.json=''{"apiKey": "{{ .apiKey }}","projectID": "${PROJECT_ID}", "loadbalancer": "kube-vip://", "facility": "${FACILITY}"}'''
         kubectl create secret generic -n kube-system metal-cloud-config --from-literal="$${SECRET_DATA}" || (sleep 1 && kubectl create secret generic -n kube-system metal-cloud-config --from-literal="$${SECRET_DATA}") || (sleep 1 && kubectl create secret generic -n kube-system metal-cloud-config --from-literal="$${SECRET_DATA}")
         kubectl apply -f $${CPEM_YAML} || (sleep 1 && kubectl apply -f $${CPEM_YAML}) || (sleep 1 && kubectl apply -f $${CPEM_YAML})

--- a/templates/cluster-template-kube-vip.yaml
+++ b/templates/cluster-template-kube-vip.yaml
@@ -1,37 +1,17 @@
-kind: KubeadmControlPlane
-apiVersion: controlplane.cluster.x-k8s.io/v1beta1
+apiVersion: bootstrap.cluster.x-k8s.io/v1beta1
+kind: KubeadmConfigTemplate
 metadata:
-  name: "${CLUSTER_NAME}-control-plane"
+  name: ${CLUSTER_NAME}-worker-a
 spec:
-  version: ${KUBERNETES_VERSION}
-  replicas: ${CONTROL_PLANE_MACHINE_COUNT}
-  machineTemplate:
-    infrastructureRef:
-      apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
-      kind: PacketMachineTemplate
-      name: "${CLUSTER_NAME}-control-plane"
-  kubeadmConfigSpec:
-    clusterConfiguration:
-      apiServer:
-          extraArgs:
-              cloud-provider: external
-      controllerManager:
-          extraArgs:
-              cloud-provider: external
-    initConfiguration:
-      nodeRegistration:
-        kubeletExtraArgs:
-          cloud-provider: external
-          provider-id: "equinixmetal://{{ `{{ v1.instance_id }}` }}"
-    joinConfiguration:
-      nodeRegistration:
-        ignorePreflightErrors:
-        - DirAvailable--etc-kubernetes-manifests
-        kubeletExtraArgs:
-          cloud-provider: external
-          provider-id: "equinixmetal://{{ `{{ v1.instance_id }}` }}"
-    preKubeadmCommands:
-      - |
+  template:
+    spec:
+      joinConfiguration:
+        nodeRegistration:
+          kubeletExtraArgs:
+            cloud-provider: external
+            provider-id: equinixmetal://{{ `{{ v1.instance_id }}` }}
+      preKubeadmCommands:
+      - |-
         sed -ri '/\sswap\s/s/^#?/#/' /etc/fstab
         swapoff -a
         mount -a
@@ -55,86 +35,40 @@ spec:
         TRIMMED_KUBERNETES_VERSION=$(echo {{ .kubernetesVersion }} | sed 's/\./\\\\./g' | sed 's/^v//')
         RESOLVED_KUBERNETES_VERSION=$(apt-cache madison kubelet | awk -v VERSION=$${TRIMMED_KUBERNETES_VERSION} '$3~ VERSION { print $3 }' | head -n1)
         DEBIAN_FRONTEND=noninteractive apt-get install -y containerd kubelet=$${RESOLVED_KUBERNETES_VERSION} kubeadm=$${RESOLVED_KUBERNETES_VERSION} kubectl=$${RESOLVED_KUBERNETES_VERSION}
-        curl -o /run/metadata.json -fsSL https://metadata.platformequinix.com/metadata
-        for i in $(cat /run/metadata.json | jq -r '.bgp_neighbors[0].peer_ips[]'); do
-          ip route add $i via $(cat /run/metadata.json | jq -r '.network.addresses[] | select(.public == false and .address_family == 4) | .gateway')
-        done
-        KVVERSION="${KUBE_VIP_VERSION:=v0.4.2}"
-        ctr image pull ghcr.io/kube-vip/kube-vip:$${KVVERSION}
-        ctr run --rm --net-host ghcr.io/kube-vip/kube-vip:$KVVERSION vip /kube-vip manifest pod \
-        --interface "lo" \
-        --vip "{{ .controlPlaneEndpoint }}" \
-        --controlplane \
-        --services \
-        --bgp \
-        --peerAS $(cat /run/metadata.json | jq -r '.bgp_neighbors[0].peer_as') \
-        --peerAddress $(cat /run/metadata.json | jq -r '.bgp_neighbors[0].peer_ips[0]') \
-        --localAS $(cat /run/metadata.json | jq -r '.bgp_neighbors[0].customer_as') \
-        --bgpRouterID $(cat /run/metadata.json | jq -r '.bgp_neighbors[0].customer_ip') > /etc/kubernetes/manifests/vip.yaml
-        rm /run/metadata.json
-    postKubeadmCommands:
-      - |
-        if [ -f "/run/kubeadm/kubeadm.yaml" ]; then
-          export KUBECONFIG=/etc/kubernetes/admin.conf
-          export CPEM_YAML=https://raw.githubusercontent.com/detiber/packet-ccm/test/deploy/template/deployment.yaml
-          export SECRET_DATA='cloud-sa.json=''{"apiKey": "{{ .apiKey }}","projectID": "${PROJECT_ID}", "loadbalancer": "kube-vip://", "facility": "${FACILITY}"}'''
-          kubectl create secret generic -n kube-system metal-cloud-config --from-literal="$${SECRET_DATA}" || (sleep 1 && kubectl create secret generic -n kube-system metal-cloud-config --from-literal="$${SECRET_DATA}") || (sleep 1 && kubectl create secret generic -n kube-system metal-cloud-config --from-literal="$${SECRET_DATA}")
-          kubectl apply -f $${CPEM_YAML} || (sleep 1 && kubectl apply -f $${CPEM_YAML}) || (sleep 1 && kubectl apply -f $${CPEM_YAML})
-        fi
----
-apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
-kind: PacketMachineTemplate
-metadata:
-  name: "${CLUSTER_NAME}-control-plane"
-spec:
-  template:
-    spec:
-      os: "${NODE_OS:=ubuntu_18_04}"
-      billingCycle: hourly
-      machineType: "${CONTROLPLANE_NODE_TYPE}"
-      sshKeys:
-        - "${SSH_KEY}"
-      tags: []
 ---
 apiVersion: cluster.x-k8s.io/v1beta1
 kind: Cluster
 metadata:
-  name: "${CLUSTER_NAME}"
+  labels:
+    cni: ${CLUSTER_NAME}-kube-vip
+  name: ${CLUSTER_NAME}
 spec:
   clusterNetwork:
     pods:
       cidrBlocks:
-        - ${POD_CIDR:=192.168.0.0/16}
+      - ${POD_CIDR:=192.168.0.0/16}
     services:
       cidrBlocks:
-        - ${SERVICE_CIDR:=172.26.0.0/16}
-  infrastructureRef:
-    apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
-    kind: PacketCluster
-    name: "${CLUSTER_NAME}"
+      - ${SERVICE_CIDR:=172.26.0.0/16}
   controlPlaneRef:
     apiVersion: controlplane.cluster.x-k8s.io/v1beta1
     kind: KubeadmControlPlane
-    name: "${CLUSTER_NAME}-control-plane"
----
-apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
-kind: PacketCluster
-metadata:
-  name: "${CLUSTER_NAME}"
-spec:
-  projectID: "${PROJECT_ID}"
-  facility: "${FACILITY}"
+    name: ${CLUSTER_NAME}-control-plane
+  infrastructureRef:
+    apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+    kind: PacketCluster
+    name: ${CLUSTER_NAME}
 ---
 apiVersion: cluster.x-k8s.io/v1beta1
 kind: MachineDeployment
 metadata:
-  name: ${CLUSTER_NAME}-worker-a
   labels:
     cluster.x-k8s.io/cluster-name: ${CLUSTER_NAME}
     pool: worker-a
+  name: ${CLUSTER_NAME}-worker-a
 spec:
-  replicas: ${WORKER_MACHINE_COUNT}
   clusterName: ${CLUSTER_NAME}
+  replicas: ${WORKER_MACHINE_COUNT}
   selector:
     matchLabels:
       cluster.x-k8s.io/cluster-name: ${CLUSTER_NAME}
@@ -145,17 +79,123 @@ spec:
         cluster.x-k8s.io/cluster-name: ${CLUSTER_NAME}
         pool: worker-a
     spec:
-      version: ${KUBERNETES_VERSION}
-      clusterName: ${CLUSTER_NAME}
       bootstrap:
         configRef:
-          name: ${CLUSTER_NAME}-worker-a
           apiVersion: bootstrap.cluster.x-k8s.io/v1beta1
           kind: KubeadmConfigTemplate
+          name: ${CLUSTER_NAME}-worker-a
+      clusterName: ${CLUSTER_NAME}
       infrastructureRef:
-        name: ${CLUSTER_NAME}-worker-a
         apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
         kind: PacketMachineTemplate
+        name: ${CLUSTER_NAME}-worker-a
+      version: ${KUBERNETES_VERSION}
+---
+apiVersion: controlplane.cluster.x-k8s.io/v1beta1
+kind: KubeadmControlPlane
+metadata:
+  name: ${CLUSTER_NAME}-control-plane
+spec:
+  kubeadmConfigSpec:
+    clusterConfiguration:
+      apiServer:
+        extraArgs:
+          cloud-provider: external
+      controllerManager:
+        extraArgs:
+          cloud-provider: external
+    initConfiguration:
+      nodeRegistration:
+        kubeletExtraArgs:
+          cloud-provider: external
+          provider-id: equinixmetal://{{ `{{ v1.instance_id }}` }}
+    joinConfiguration:
+      nodeRegistration:
+        ignorePreflightErrors:
+        - DirAvailable--etc-kubernetes-manifests
+        kubeletExtraArgs:
+          cloud-provider: external
+          provider-id: equinixmetal://{{ `{{ v1.instance_id }}` }}
+    postKubeadmCommands:
+    - |-
+      if [ -f "/run/kubeadm/kubeadm.yaml" ]; then
+        export KUBECONFIG=/etc/kubernetes/admin.conf
+        export CPEM_YAML=https://raw.githubusercontent.com/detiber/packet-ccm/test/deploy/template/deployment.yaml
+        export SECRET_DATA='cloud-sa.json=''{"apiKey": "{{ .apiKey }}","projectID": "${PROJECT_ID}", "loadbalancer": "kube-vip://", "facility": "${FACILITY}"}'''
+        kubectl create secret generic -n kube-system metal-cloud-config --from-literal="$${SECRET_DATA}" || (sleep 1 && kubectl create secret generic -n kube-system metal-cloud-config --from-literal="$${SECRET_DATA}") || (sleep 1 && kubectl create secret generic -n kube-system metal-cloud-config --from-literal="$${SECRET_DATA}")
+        kubectl apply -f $${CPEM_YAML} || (sleep 1 && kubectl apply -f $${CPEM_YAML}) || (sleep 1 && kubectl apply -f $${CPEM_YAML})
+      fi
+    preKubeadmCommands:
+    - |
+      sed -ri '/\sswap\s/s/^#?/#/' /etc/fstab
+      swapoff -a
+      mount -a
+      cat <<EOF > /etc/modules-load.d/containerd.conf
+      overlay
+      br_netfilter
+      EOF
+      modprobe overlay
+      modprobe br_netfilter
+      cat <<EOF > /etc/sysctl.d/99-kubernetes-cri.conf
+      net.bridge.bridge-nf-call-iptables  = 1
+      net.ipv4.ip_forward                 = 1
+      net.bridge.bridge-nf-call-ip6tables = 1
+      EOF
+      sysctl --system
+      apt-get -y update
+      DEBIAN_FRONTEND=noninteractive apt-get install -y apt-transport-https ca-certificates curl gnupg lsb-release linux-generic jq
+      curl -s https://packages.cloud.google.com/apt/doc/apt-key.gpg | apt-key add -
+      echo "deb https://apt.kubernetes.io/ kubernetes-xenial main" > /etc/apt/sources.list.d/kubernetes.list
+      apt-get update -y
+      TRIMMED_KUBERNETES_VERSION=$(echo {{ .kubernetesVersion }} | sed 's/\./\\\\./g' | sed 's/^v//')
+      RESOLVED_KUBERNETES_VERSION=$(apt-cache madison kubelet | awk -v VERSION=$${TRIMMED_KUBERNETES_VERSION} '$3~ VERSION { print $3 }' | head -n1)
+      DEBIAN_FRONTEND=noninteractive apt-get install -y containerd kubelet=$${RESOLVED_KUBERNETES_VERSION} kubeadm=$${RESOLVED_KUBERNETES_VERSION} kubectl=$${RESOLVED_KUBERNETES_VERSION}
+      curl -o /run/metadata.json -fsSL https://metadata.platformequinix.com/metadata
+      for i in $(cat /run/metadata.json | jq -r '.bgp_neighbors[0].peer_ips[]'); do
+        ip route add $i via $(cat /run/metadata.json | jq -r '.network.addresses[] | select(.public == false and .address_family == 4) | .gateway')
+      done
+      KVVERSION="${KUBE_VIP_VERSION:=v0.4.2}"
+      ctr image pull ghcr.io/kube-vip/kube-vip:$${KVVERSION}
+      ctr run --rm --net-host ghcr.io/kube-vip/kube-vip:$KVVERSION vip /kube-vip manifest pod \
+      --interface "lo" \
+      --vip "{{ .controlPlaneEndpoint }}" \
+      --controlplane \
+      --services \
+      --bgp \
+      --peerAS $(cat /run/metadata.json | jq -r '.bgp_neighbors[0].peer_as') \
+      --peerAddress $(cat /run/metadata.json | jq -r '.bgp_neighbors[0].peer_ips[0]') \
+      --localAS $(cat /run/metadata.json | jq -r '.bgp_neighbors[0].customer_as') \
+      --bgpRouterID $(cat /run/metadata.json | jq -r '.bgp_neighbors[0].customer_ip') > /etc/kubernetes/manifests/vip.yaml
+      rm /run/metadata.json
+  machineTemplate:
+    infrastructureRef:
+      apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+      kind: PacketMachineTemplate
+      name: ${CLUSTER_NAME}-control-plane
+  replicas: ${CONTROL_PLANE_MACHINE_COUNT}
+  version: ${KUBERNETES_VERSION}
+---
+apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+kind: PacketCluster
+metadata:
+  name: ${CLUSTER_NAME}
+spec:
+  facility: ${FACILITY}
+  projectID: ${PROJECT_ID}
+---
+apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+kind: PacketMachineTemplate
+metadata:
+  name: ${CLUSTER_NAME}-control-plane
+spec:
+  template:
+    spec:
+      billingCycle: hourly
+      machineType: ${CONTROLPLANE_NODE_TYPE}
+      os: ${NODE_OS:=ubuntu_18_04}
+      sshKeys:
+      - ${SSH_KEY}
+      tags: []
 ---
 apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
 kind: PacketMachineTemplate
@@ -164,47 +204,9 @@ metadata:
 spec:
   template:
     spec:
-      os: "${NODE_OS:=ubuntu_18_04}"
       billingCycle: hourly
-      machineType: "${WORKER_NODE_TYPE}"
+      machineType: ${WORKER_NODE_TYPE}
+      os: ${NODE_OS:=ubuntu_18_04}
       sshKeys:
-        - "${SSH_KEY}"
+      - ${SSH_KEY}
       tags: []
----
-kind: KubeadmConfigTemplate
-apiVersion: bootstrap.cluster.x-k8s.io/v1beta1
-metadata:
-  name: "${CLUSTER_NAME}-worker-a"
-spec:
-  template:
-    spec:
-      joinConfiguration:
-        nodeRegistration:
-          kubeletExtraArgs:
-            cloud-provider: external
-            provider-id: "equinixmetal://{{ `{{ v1.instance_id }}` }}"
-      preKubeadmCommands:
-        - |
-          sed -ri '/\sswap\s/s/^#?/#/' /etc/fstab
-          swapoff -a
-          mount -a
-          cat <<EOF > /etc/modules-load.d/containerd.conf
-          overlay
-          br_netfilter
-          EOF
-          modprobe overlay
-          modprobe br_netfilter
-          cat <<EOF > /etc/sysctl.d/99-kubernetes-cri.conf
-          net.bridge.bridge-nf-call-iptables  = 1
-          net.ipv4.ip_forward                 = 1
-          net.bridge.bridge-nf-call-ip6tables = 1
-          EOF
-          sysctl --system
-          apt-get -y update
-          DEBIAN_FRONTEND=noninteractive apt-get install -y apt-transport-https ca-certificates curl gnupg lsb-release linux-generic jq
-          curl -s https://packages.cloud.google.com/apt/doc/apt-key.gpg | apt-key add -
-          echo "deb https://apt.kubernetes.io/ kubernetes-xenial main" > /etc/apt/sources.list.d/kubernetes.list
-          apt-get update -y
-          TRIMMED_KUBERNETES_VERSION=$(echo {{ .kubernetesVersion }} | sed 's/\./\\\\./g' | sed 's/^v//')
-          RESOLVED_KUBERNETES_VERSION=$(apt-cache madison kubelet | awk -v VERSION=$${TRIMMED_KUBERNETES_VERSION} '$3~ VERSION { print $3 }' | head -n1)
-          DEBIAN_FRONTEND=noninteractive apt-get install -y containerd kubelet=$${RESOLVED_KUBERNETES_VERSION} kubeadm=$${RESOLVED_KUBERNETES_VERSION} kubectl=$${RESOLVED_KUBERNETES_VERSION}

--- a/templates/cluster-template-kube-vip.yaml
+++ b/templates/cluster-template-kube-vip.yaml
@@ -160,7 +160,6 @@ spec:
       --interface "lo" \
       --vip "{{ .controlPlaneEndpoint }}" \
       --controlplane \
-      --services \
       --bgp \
       --peerAS $(cat /run/metadata.json | jq -r '.bgp_neighbors[0].peer_as') \
       --peerAddress $(cat /run/metadata.json | jq -r '.bgp_neighbors[0].peer_ips[0]') \

--- a/templates/cluster-template.yaml
+++ b/templates/cluster-template.yaml
@@ -55,6 +55,11 @@ spec:
         TRIMMED_KUBERNETES_VERSION=$(echo {{ .kubernetesVersion }} | sed 's/\./\\\\./g' | sed 's/^v//')
         RESOLVED_KUBERNETES_VERSION=$(apt-cache madison kubelet | awk -v VERSION=$${TRIMMED_KUBERNETES_VERSION} '$3~ VERSION { print $3 }' | head -n1)
         DEBIAN_FRONTEND=noninteractive apt-get install -y containerd kubelet=$${RESOLVED_KUBERNETES_VERSION} kubeadm=$${RESOLVED_KUBERNETES_VERSION} kubectl=$${RESOLVED_KUBERNETES_VERSION}
+        curl -o /run/metadata.json -fsSL https://metadata.platformequinix.com/metadata
+        for i in $(cat /run/metadata.json | jq -r '.bgp_neighbors[0].peer_ips[]'); do
+          ip route add $i via $(cat /run/metadata.json | jq -r '.network.addresses[] | select(.public == false and .address_family == 4) | .gateway')
+        done
+        rm /run/metadata.json
         ping -c 3 -q {{ .controlPlaneEndpoint }} && echo OK || ip addr add {{ .controlPlaneEndpoint }} dev lo
     postKubeadmCommands:
       - |

--- a/templates/cluster-template.yaml
+++ b/templates/cluster-template.yaml
@@ -30,50 +30,51 @@ spec:
           cloud-provider: external
           provider-id: "equinixmetal://{{ `{{ v1.instance_id }}` }}"
     preKubeadmCommands:
-      - sed -ri '/\sswap\s/s/^#?/#/' /etc/fstab
-      - swapoff -a
-      - mount -a
       - |
+        sed -ri '/\sswap\s/s/^#?/#/' /etc/fstab
+        swapoff -a
+        mount -a
         cat <<EOF > /etc/modules-load.d/containerd.conf
         overlay
         br_netfilter
         EOF
-      - modprobe overlay
-      - modprobe br_netfilter
-      - |
+        modprobe overlay
+        modprobe br_netfilter
         cat <<EOF > /etc/sysctl.d/99-kubernetes-cri.conf
         net.bridge.bridge-nf-call-iptables  = 1
         net.ipv4.ip_forward                 = 1
         net.bridge.bridge-nf-call-ip6tables = 1
         EOF
-      - sysctl --system
-      - |
+        sysctl --system
         apt-get -y update
-        DEBIAN_FRONTEND=noninteractive apt-get install -y apt-transport-https curl
+        DEBIAN_FRONTEND=noninteractive apt-get install -y apt-transport-https ca-certificates curl gnupg lsb-release linux-generic jq
         curl -s https://packages.cloud.google.com/apt/doc/apt-key.gpg | apt-key add -
         echo "deb https://apt.kubernetes.io/ kubernetes-xenial main" > /etc/apt/sources.list.d/kubernetes.list
         apt-get update -y
-        TRIMMED_KUBERNETES_VERSION=$(echo {{ .kubernetesVersion }} | sed 's/\./\\./g' | sed 's/^v//')
-        RESOLVED_KUBERNETES_VERSION=$(apt-cache policy kubelet | awk -v VERSION=$${TRIMMED_KUBERNETES_VERSION} '$1~ VERSION { print $1 }' | head -n1)
-        apt-get install -y ca-certificates socat jq ebtables apt-transport-https cloud-utils prips containerd kubelet=$${RESOLVED_KUBERNETES_VERSION} kubeadm=$${RESOLVED_KUBERNETES_VERSION} kubectl=$${RESOLVED_KUBERNETES_VERSION}
-      - systemctl daemon-reload
-      - systemctl enable containerd
-      - systemctl start containerd
-      - |
-        if [ -f "/run/kubeadm/kubeadm.yaml" ]; then
-          KVVERSION="${KUBE_VIP_VERSION:=v0.4.2}"
-          ctr image pull ghcr.io/kube-vip/kube-vip:$${KVVERSION}
-          mkdir -p /etc/kubernetes/manifests/
-          ctr run --rm --net-host ghcr.io/kube-vip/kube-vip:$${KVVERSION} vip /kube-vip manifest pod --interface "lo" --vip "{{ .controlPlaneEndpoint }}" --controlplane --bgp --metal --metalKey "{{ .apiKey }}" --metalProjectID  "${PROJECT_ID}" | tee  /etc/kubernetes/manifests/kube-vip.yaml
-        fi
+        TRIMMED_KUBERNETES_VERSION=$(echo {{ .kubernetesVersion }} | sed 's/\./\\\\./g' | sed 's/^v//')
+        RESOLVED_KUBERNETES_VERSION=$(apt-cache madison kubelet | awk -v VERSION=$${TRIMMED_KUBERNETES_VERSION} '$3~ VERSION { print $3 }' | head -n1)
+        DEBIAN_FRONTEND=noninteractive apt-get install -y containerd kubelet=$${RESOLVED_KUBERNETES_VERSION} kubeadm=$${RESOLVED_KUBERNETES_VERSION} kubectl=$${RESOLVED_KUBERNETES_VERSION}
+        curl -o /run/metadata.json -fsSL https://metadata.platformequinix.com/metadata
+        for i in $(cat /run/metadata.json | jq -r '.bgp_neighbors[0].peer_ips[]'); do
+          ip route add $i via $(cat /run/metadata.json | jq -r '.network.addresses[] | select(.public == false and .address_family == 4) | .gateway')
+        done
+        KVVERSION="${KUBE_VIP_VERSION:=v0.4.2}"
+        ctr image pull ghcr.io/kube-vip/kube-vip:$${KVVERSION}
+        echo "{{ .controlPlaneEndpoint }}"
+        ctr run --rm --net-host ghcr.io/kube-vip/kube-vip:$KVVERSION vip /kube-vip manifest pod \
+        --interface "lo" \
+        --vip "{{ .controlPlaneEndpoint }}" \
+        --controlplane \
+        --services \
+        --bgp \
+        --peerAS $(cat /run/metadata.json | jq -r '.bgp_neighbors[0].peer_as') \
+        --peerAddress $(cat /run/metadata.json | jq -r '.bgp_neighbors[0].peer_ips[0]') \
+        --localAS $(cat /run/metadata.json | jq -r '.bgp_neighbors[0].customer_as') \
+        --bgpRouterID $(cat /run/metadata.json | jq -r '.bgp_neighbors[0].customer_ip') >/etc/kubernetes/manifests/vip.yaml
+        rm /run/metadata.json
     postKubeadmCommands:
       - |
-        if [ -f "/run/kubeadm/kubeadm-join-config.yaml" ]; then
-          KVVERSION="${KUBE_VIP_VERSION:=v0.4.2}"
-          ctr image pull ghcr.io/kube-vip/kube-vip:$${KVVERSION}
-          ctr run --rm --net-host ghcr.io/kube-vip/kube-vip:$${KVVERSION} vip /kube-vip manifest pod --interface "lo" --vip "{{ .controlPlaneEndpoint }}" --controlplane --bgp --metal --metalKey "{{ .apiKey }}" --metalProjectID "${PROJECT_ID}" | tee  /etc/kubernetes/manifests/kube-vip.yaml
-        fi
-      - |
+        curl -o /run/metadata.json -fsSL https://metadata.platformequinix.com/metadata
         if [ -f "/run/kubeadm/kubeadm.yaml" ]; then
           export KUBECONFIG=/etc/kubernetes/admin.conf
           export CPEM_YAML=https://github.com/equinix/cloud-provider-equinix-metal/releases/download/v3.4.0/deployment.yaml
@@ -81,6 +82,7 @@ spec:
           kubectl create secret generic -n kube-system metal-cloud-config --from-literal="$${SECRET_DATA}" || (sleep 1 && kubectl create secret generic -n kube-system metal-cloud-config --from-literal="$${SECRET_DATA}") || (sleep 1 && kubectl create secret generic -n kube-system metal-cloud-config --from-literal="$${SECRET_DATA}")
           kubectl apply -f $${CPEM_YAML} || (sleep 1 && kubectl apply -f $${CPEM_YAML}) || (sleep 1 && kubectl apply -f $${CPEM_YAML})
         fi
+        rm /run/metadata.json
 ---
 apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
 kind: PacketMachineTemplate
@@ -184,32 +186,27 @@ spec:
             cloud-provider: external
             provider-id: "equinixmetal://{{ `{{ v1.instance_id }}` }}"
       preKubeadmCommands:
-        - sed -ri '/\sswap\s/s/^#?/#/' /etc/fstab
-        - swapoff -a
-        - mount -a
         - |
+          sed -ri '/\sswap\s/s/^#?/#/' /etc/fstab
+          swapoff -a
+          mount -a
           cat <<EOF > /etc/modules-load.d/containerd.conf
           overlay
           br_netfilter
           EOF
-        - modprobe overlay
-        - modprobe br_netfilter
-        - |
+          modprobe overlay
+          modprobe br_netfilter
           cat <<EOF > /etc/sysctl.d/99-kubernetes-cri.conf
           net.bridge.bridge-nf-call-iptables  = 1
           net.ipv4.ip_forward                 = 1
           net.bridge.bridge-nf-call-ip6tables = 1
           EOF
-        - sysctl --system
-        - |
+          sysctl --system
           apt-get -y update
-          DEBIAN_FRONTEND=noninteractive apt-get install -y apt-transport-https curl
+          DEBIAN_FRONTEND=noninteractive apt-get install -y apt-transport-https ca-certificates curl gnupg lsb-release linux-generic jq
           curl -s https://packages.cloud.google.com/apt/doc/apt-key.gpg | apt-key add -
           echo "deb https://apt.kubernetes.io/ kubernetes-xenial main" > /etc/apt/sources.list.d/kubernetes.list
           apt-get update -y
           TRIMMED_KUBERNETES_VERSION=$(echo {{ .kubernetesVersion }} | sed 's/\./\\./g' | sed 's/^v//')
           RESOLVED_KUBERNETES_VERSION=$(apt-cache policy kubelet | awk -v VERSION=$${TRIMMED_KUBERNETES_VERSION} '$1~ VERSION { print $1 }' | head -n1)
-          apt-get install -y ca-certificates socat jq ebtables apt-transport-https cloud-utils prips containerd kubelet=$${RESOLVED_KUBERNETES_VERSION} kubeadm=$${RESOLVED_KUBERNETES_VERSION} kubectl=$${RESOLVED_KUBERNETES_VERSION}
-        - systemctl daemon-reload
-        - systemctl enable containerd
-        - systemctl start containerd
+          DEBIAN_FRONTEND=noninteractive apt-get install -y containerd kubelet=$${RESOLVED_KUBERNETES_VERSION} kubeadm=$${RESOLVED_KUBERNETES_VERSION} kubectl=$${RESOLVED_KUBERNETES_VERSION}

--- a/templates/cluster-template.yaml
+++ b/templates/cluster-template.yaml
@@ -114,6 +114,7 @@ metadata:
 spec:
   projectID: "${PROJECT_ID}"
   facility: "${FACILITY}"
+  vipManager: "CPEM"
 ---
 apiVersion: cluster.x-k8s.io/v1beta1
 kind: MachineDeployment

--- a/templates/cluster-template.yaml
+++ b/templates/cluster-template.yaml
@@ -66,16 +66,7 @@ spec:
           mkdir -p /etc/kubernetes/manifests/
           ctr run --rm --net-host ghcr.io/kube-vip/kube-vip:$${KVVERSION} vip /kube-vip manifest pod --interface "lo" --vip "{{ .controlPlaneEndpoint }}" --controlplane --bgp --metal --metalKey "{{ .apiKey }}" --metalProjectID "b264ba74-f3bd-49f0-ae24-b0953765b7aa" | tee  /etc/kubernetes/manifests/kube-vip.yaml
         fi
-      # - ping -c 3 -q {{ .controlPlaneEndpoint }} && echo OK || ip addr add {{ .controlPlaneEndpoint }} dev lo
     postKubeadmCommands:
-      # - |
-      #   cat <<EOF >> /etc/network/interfaces
-      #   auto lo:0
-      #   iface lo:0 inet static
-      #     address {{ .controlPlaneEndpoint }}
-      #     netmask 255.255.255.255
-      #   EOF
-      # - systemctl restart networking
       - |
         if [ -f "/run/kubeadm/kubeadm-join-config.yaml" ]; then
           KVVERSION=$(curl -sL https://api.github.com/repos/kube-vip/kube-vip/releases | jq -r ".[0].name")

--- a/templates/cluster-template.yaml
+++ b/templates/cluster-template.yaml
@@ -86,7 +86,7 @@ spec:
         if [ -f "/run/kubeadm/kubeadm.yaml" ]; then
           export KUBECONFIG=/etc/kubernetes/admin.conf
           export CPEM_YAML=https://github.com/equinix/cloud-provider-equinix-metal/releases/download/v3.4.0/deployment.yaml
-          export SECRET_DATA='cloud-sa.json=''{"apiKey": "{{ .apiKey }}","projectID": "${PROJECT_ID}", "eipTag": "cluster-api-provider-packet:cluster-id:${CLUSTER_NAME}", "eipHealthCheckUseHostIP": true}'''
+          export SECRET_DATA='cloud-sa.json=''{"apiKey": "{{ .apiKey }}","projectID": "${PROJECT_ID}", "loadbalancer": "kube-vip://"}'''
           kubectl create secret generic -n kube-system metal-cloud-config --from-literal="$${SECRET_DATA}" || (sleep 1 && kubectl create secret generic -n kube-system metal-cloud-config --from-literal="$${SECRET_DATA}") || (sleep 1 && kubectl create secret generic -n kube-system metal-cloud-config --from-literal="$${SECRET_DATA}")
           kubectl apply -f $${CPEM_YAML} || (sleep 1 && kubectl apply -f $${CPEM_YAML}) || (sleep 1 && kubectl apply -f $${CPEM_YAML})
         fi

--- a/templates/cluster-template.yaml
+++ b/templates/cluster-template.yaml
@@ -25,8 +25,7 @@ spec:
           provider-id: "equinixmetal://{{ `{{ v1.instance_id }}` }}"
     joinConfiguration:
       nodeRegistration:
-        ignorePreflightErrors:
-        - DirAvailable--etc-kubernetes-manifests
+        ignorePreflightErrors: []
         kubeletExtraArgs:
           cloud-provider: external
           provider-id: "equinixmetal://{{ `{{ v1.instance_id }}` }}"
@@ -55,29 +54,20 @@ spec:
         TRIMMED_KUBERNETES_VERSION=$(echo {{ .kubernetesVersion }} | sed 's/\./\\\\./g' | sed 's/^v//')
         RESOLVED_KUBERNETES_VERSION=$(apt-cache madison kubelet | awk -v VERSION=$${TRIMMED_KUBERNETES_VERSION} '$3~ VERSION { print $3 }' | head -n1)
         DEBIAN_FRONTEND=noninteractive apt-get install -y containerd kubelet=$${RESOLVED_KUBERNETES_VERSION} kubeadm=$${RESOLVED_KUBERNETES_VERSION} kubectl=$${RESOLVED_KUBERNETES_VERSION}
-        curl -o /run/metadata.json -fsSL https://metadata.platformequinix.com/metadata
-        for i in $(cat /run/metadata.json | jq -r '.bgp_neighbors[0].peer_ips[]'); do
-          ip route add $i via $(cat /run/metadata.json | jq -r '.network.addresses[] | select(.public == false and .address_family == 4) | .gateway')
-        done
-        KVVERSION="${KUBE_VIP_VERSION:=v0.4.2}"
-        ctr image pull ghcr.io/kube-vip/kube-vip:$${KVVERSION}
-        ctr run --rm --net-host ghcr.io/kube-vip/kube-vip:$KVVERSION vip /kube-vip manifest pod \
-        --interface "lo" \
-        --vip "{{ .controlPlaneEndpoint }}" \
-        --controlplane \
-        --services \
-        --bgp \
-        --peerAS $(cat /run/metadata.json | jq -r '.bgp_neighbors[0].peer_as') \
-        --peerAddress $(cat /run/metadata.json | jq -r '.bgp_neighbors[0].peer_ips[0]') \
-        --localAS $(cat /run/metadata.json | jq -r '.bgp_neighbors[0].customer_as') \
-        --bgpRouterID $(cat /run/metadata.json | jq -r '.bgp_neighbors[0].customer_ip') > /etc/kubernetes/manifests/vip.yaml
-        rm /run/metadata.json
+        ping -c 3 -q {{ .controlPlaneEndpoint }} && echo OK || ip addr add {{ .controlPlaneEndpoint }} dev lo
     postKubeadmCommands:
       - |
+        cat <<EOF >> /etc/network/interfaces
+        auto lo:0
+        iface lo:0 inet static
+          address {{ .controlPlaneEndpoint }}
+          netmask 255.255.255.255
+        EOF
+        systemctl restart networking
         if [ -f "/run/kubeadm/kubeadm.yaml" ]; then
           export KUBECONFIG=/etc/kubernetes/admin.conf
           export CPEM_YAML=https://github.com/equinix/cloud-provider-equinix-metal/releases/download/v3.4.0/deployment.yaml
-          export SECRET_DATA='cloud-sa.json=''{"apiKey": "{{ .apiKey }}","projectID": "${PROJECT_ID}", "loadbalancer": "kube-vip://", "facility": "${FACILITY}"}'''
+          export SECRET_DATA='cloud-sa.json=''{"apiKey": "{{ .apiKey }}","projectID": "${PROJECT_ID}", "eipTag": "cluster-api-provider-packet:cluster-id:${CLUSTER_NAME}", "eipHealthCheckUseHostIP": true}'''
           kubectl create secret generic -n kube-system metal-cloud-config --from-literal="$${SECRET_DATA}" || (sleep 1 && kubectl create secret generic -n kube-system metal-cloud-config --from-literal="$${SECRET_DATA}") || (sleep 1 && kubectl create secret generic -n kube-system metal-cloud-config --from-literal="$${SECRET_DATA}")
           kubectl apply -f $${CPEM_YAML} || (sleep 1 && kubectl apply -f $${CPEM_YAML}) || (sleep 1 && kubectl apply -f $${CPEM_YAML})
         fi
@@ -205,6 +195,6 @@ spec:
           curl -s https://packages.cloud.google.com/apt/doc/apt-key.gpg | apt-key add -
           echo "deb https://apt.kubernetes.io/ kubernetes-xenial main" > /etc/apt/sources.list.d/kubernetes.list
           apt-get update -y
-          TRIMMED_KUBERNETES_VERSION=$(echo {{ .kubernetesVersion }} | sed 's/\./\\./g' | sed 's/^v//')
+          TRIMMED_KUBERNETES_VERSION=$(echo {{ .kubernetesVersion }} | sed 's/\./\\\\./g' | sed 's/^v//')
           RESOLVED_KUBERNETES_VERSION=$(apt-cache policy kubelet | awk -v VERSION=$${TRIMMED_KUBERNETES_VERSION} '$1~ VERSION { print $1 }' | head -n1)
           DEBIAN_FRONTEND=noninteractive apt-get install -y containerd kubelet=$${RESOLVED_KUBERNETES_VERSION} kubeadm=$${RESOLVED_KUBERNETES_VERSION} kubectl=$${RESOLVED_KUBERNETES_VERSION}

--- a/templates/cluster-template.yaml
+++ b/templates/cluster-template.yaml
@@ -69,7 +69,7 @@ spec:
         --peerAS $(cat /run/metadata.json | jq -r '.bgp_neighbors[0].peer_as') \
         --peerAddress $(cat /run/metadata.json | jq -r '.bgp_neighbors[0].peer_ips[0]') \
         --localAS $(cat /run/metadata.json | jq -r '.bgp_neighbors[0].customer_as') \
-        --bgpRouterID $(cat /run/metadata.json | jq -r '.bgp_neighbors[0].customer_ip') >/etc/kubernetes/manifests/vip.yaml
+        --bgpRouterID $(cat /run/metadata.json | jq -r '.bgp_neighbors[0].customer_ip') > /etc/kubernetes/manifests/vip.yaml
         rm /run/metadata.json
     postKubeadmCommands:
       - |

--- a/templates/cluster-template.yaml
+++ b/templates/cluster-template.yaml
@@ -61,17 +61,17 @@ spec:
       - systemctl start containerd
       - |
         if [ -f "/run/kubeadm/kubeadm.yaml" ]; then
-          KVVERSION="v0.4.2"
+          KVVERSION="${KUBE_VIP_VERSION:=v0.4.2}"
           ctr image pull ghcr.io/kube-vip/kube-vip:$${KVVERSION}
           mkdir -p /etc/kubernetes/manifests/
-          ctr run --rm --net-host ghcr.io/kube-vip/kube-vip:$${KVVERSION} vip /kube-vip manifest pod --interface "lo" --vip "{{ .controlPlaneEndpoint }}" --controlplane --bgp --metal --metalKey "{{ .apiKey }}" --metalProjectID "b264ba74-f3bd-49f0-ae24-b0953765b7aa" | tee  /etc/kubernetes/manifests/kube-vip.yaml
+          ctr run --rm --net-host ghcr.io/kube-vip/kube-vip:$${KVVERSION} vip /kube-vip manifest pod --interface "lo" --vip "{{ .controlPlaneEndpoint }}" --controlplane --bgp --metal --metalKey "{{ .apiKey }}" --metalProjectID  "${PROJECT_ID}" | tee  /etc/kubernetes/manifests/kube-vip.yaml
         fi
     postKubeadmCommands:
       - |
         if [ -f "/run/kubeadm/kubeadm-join-config.yaml" ]; then
-          KVVERSION="v0.4.2"
+          KVVERSION="${KUBE_VIP_VERSION:=v0.4.2}"
           ctr image pull ghcr.io/kube-vip/kube-vip:$${KVVERSION}
-          ctr run --rm --net-host ghcr.io/kube-vip/kube-vip:$${KVVERSION} vip /kube-vip manifest pod --interface "lo" --vip "{{ .controlPlaneEndpoint }}" --controlplane --bgp --metal --metalKey "{{ .apiKey }}" --metalProjectID "b264ba74-f3bd-49f0-ae24-b0953765b7aa" | tee  /etc/kubernetes/manifests/kube-vip.yaml
+          ctr run --rm --net-host ghcr.io/kube-vip/kube-vip:$${KVVERSION} vip /kube-vip manifest pod --interface "lo" --vip "{{ .controlPlaneEndpoint }}" --controlplane --bgp --metal --metalKey "{{ .apiKey }}" --metalProjectID "${PROJECT_ID}" | tee  /etc/kubernetes/manifests/kube-vip.yaml
         fi
       - |
         if [ -f "/run/kubeadm/kubeadm.yaml" ]; then

--- a/templates/cluster-template.yaml
+++ b/templates/cluster-template.yaml
@@ -25,7 +25,8 @@ spec:
           provider-id: "equinixmetal://{{ `{{ v1.instance_id }}` }}"
     joinConfiguration:
       nodeRegistration:
-        ignorePreflightErrors: []
+        ignorePreflightErrors:
+        - DirAvailable--etc-kubernetes-manifests
         kubeletExtraArgs:
           cloud-provider: external
           provider-id: "equinixmetal://{{ `{{ v1.instance_id }}` }}"

--- a/templates/cluster-template.yaml
+++ b/templates/cluster-template.yaml
@@ -55,11 +55,6 @@ spec:
         TRIMMED_KUBERNETES_VERSION=$(echo {{ .kubernetesVersion }} | sed 's/\./\\\\./g' | sed 's/^v//')
         RESOLVED_KUBERNETES_VERSION=$(apt-cache madison kubelet | awk -v VERSION=$${TRIMMED_KUBERNETES_VERSION} '$3~ VERSION { print $3 }' | head -n1)
         DEBIAN_FRONTEND=noninteractive apt-get install -y containerd kubelet=$${RESOLVED_KUBERNETES_VERSION} kubeadm=$${RESOLVED_KUBERNETES_VERSION} kubectl=$${RESOLVED_KUBERNETES_VERSION}
-        curl -o /run/metadata.json -fsSL https://metadata.platformequinix.com/metadata
-        for i in $(cat /run/metadata.json | jq -r '.bgp_neighbors[0].peer_ips[]'); do
-          ip route add $i via $(cat /run/metadata.json | jq -r '.network.addresses[] | select(.public == false and .address_family == 4) | .gateway')
-        done
-        rm /run/metadata.json
         ping -c 3 -q {{ .controlPlaneEndpoint }} && echo OK || ip addr add {{ .controlPlaneEndpoint }} dev lo
     postKubeadmCommands:
       - |
@@ -69,7 +64,6 @@ spec:
           address {{ .controlPlaneEndpoint }}
           netmask 255.255.255.255
         EOF
-        systemctl restart networking
         if [ -f "/run/kubeadm/kubeadm.yaml" ]; then
           export KUBECONFIG=/etc/kubernetes/admin.conf
           export CPEM_YAML=https://github.com/equinix/cloud-provider-equinix-metal/releases/download/v3.4.0/deployment.yaml

--- a/templates/cluster-template.yaml
+++ b/templates/cluster-template.yaml
@@ -61,7 +61,7 @@ spec:
       - systemctl start containerd
       - |
         if [ -f "/run/kubeadm/kubeadm.yaml" ]; then
-          KVVERSION=$(curl -sL https://api.github.com/repos/kube-vip/kube-vip/releases | jq -r ".[0].name")
+          KVVERSION="v0.4.2"
           ctr image pull ghcr.io/kube-vip/kube-vip:$${KVVERSION}
           mkdir -p /etc/kubernetes/manifests/
           ctr run --rm --net-host ghcr.io/kube-vip/kube-vip:$${KVVERSION} vip /kube-vip manifest pod --interface "lo" --vip "{{ .controlPlaneEndpoint }}" --controlplane --bgp --metal --metalKey "{{ .apiKey }}" --metalProjectID "b264ba74-f3bd-49f0-ae24-b0953765b7aa" | tee  /etc/kubernetes/manifests/kube-vip.yaml
@@ -69,7 +69,7 @@ spec:
     postKubeadmCommands:
       - |
         if [ -f "/run/kubeadm/kubeadm-join-config.yaml" ]; then
-          KVVERSION=$(curl -sL https://api.github.com/repos/kube-vip/kube-vip/releases | jq -r ".[0].name")
+          KVVERSION="v0.4.2"
           ctr image pull ghcr.io/kube-vip/kube-vip:$${KVVERSION}
           ctr run --rm --net-host ghcr.io/kube-vip/kube-vip:$${KVVERSION} vip /kube-vip manifest pod --interface "lo" --vip "{{ .controlPlaneEndpoint }}" --controlplane --bgp --metal --metalKey "{{ .apiKey }}" --metalProjectID "b264ba74-f3bd-49f0-ae24-b0953765b7aa" | tee  /etc/kubernetes/manifests/kube-vip.yaml
         fi

--- a/templates/cluster-template.yaml
+++ b/templates/cluster-template.yaml
@@ -77,7 +77,7 @@ spec:
         if [ -f "/run/kubeadm/kubeadm.yaml" ]; then
           export KUBECONFIG=/etc/kubernetes/admin.conf
           export CPEM_YAML=https://github.com/equinix/cloud-provider-equinix-metal/releases/download/v3.4.0/deployment.yaml
-          export SECRET_DATA='cloud-sa.json=''{"apiKey": "{{ .apiKey }}","projectID": "${PROJECT_ID}", "loadbalancer": "kube-vip://"}'''
+          export SECRET_DATA='cloud-sa.json=''{"apiKey": "{{ .apiKey }}","projectID": "${PROJECT_ID}", "loadbalancer": "kube-vip://", "facility": "${FACILITY}"}'''
           kubectl create secret generic -n kube-system metal-cloud-config --from-literal="$${SECRET_DATA}" || (sleep 1 && kubectl create secret generic -n kube-system metal-cloud-config --from-literal="$${SECRET_DATA}") || (sleep 1 && kubectl create secret generic -n kube-system metal-cloud-config --from-literal="$${SECRET_DATA}")
           kubectl apply -f $${CPEM_YAML} || (sleep 1 && kubectl apply -f $${CPEM_YAML}) || (sleep 1 && kubectl apply -f $${CPEM_YAML})
         fi

--- a/templates/cluster-template.yaml
+++ b/templates/cluster-template.yaml
@@ -47,27 +47,41 @@ spec:
         net.bridge.bridge-nf-call-ip6tables = 1
         EOF
       - sysctl --system
-      - apt-get -y update
-      - DEBIAN_FRONTEND=noninteractive apt-get install -y apt-transport-https curl
-      - curl -s https://packages.cloud.google.com/apt/doc/apt-key.gpg | apt-key add -
-      - echo "deb https://apt.kubernetes.io/ kubernetes-xenial main" > /etc/apt/sources.list.d/kubernetes.list
-      - apt-get update -y
-      - TRIMMED_KUBERNETES_VERSION=$(echo {{ .kubernetesVersion }} | sed 's/\./\\./g' | sed 's/^v//')
-      - RESOLVED_KUBERNETES_VERSION=$(apt-cache policy kubelet | awk -v VERSION=$${TRIMMED_KUBERNETES_VERSION} '$1~ VERSION { print $1 }' | head -n1)
-      - apt-get install -y ca-certificates socat jq ebtables apt-transport-https cloud-utils prips containerd kubelet=$${RESOLVED_KUBERNETES_VERSION} kubeadm=$${RESOLVED_KUBERNETES_VERSION} kubectl=$${RESOLVED_KUBERNETES_VERSION}
+      - |
+        apt-get -y update
+        DEBIAN_FRONTEND=noninteractive apt-get install -y apt-transport-https curl
+        curl -s https://packages.cloud.google.com/apt/doc/apt-key.gpg | apt-key add -
+        echo "deb https://apt.kubernetes.io/ kubernetes-xenial main" > /etc/apt/sources.list.d/kubernetes.list
+        apt-get update -y
+        TRIMMED_KUBERNETES_VERSION=$(echo {{ .kubernetesVersion }} | sed 's/\./\\./g' | sed 's/^v//')
+        RESOLVED_KUBERNETES_VERSION=$(apt-cache policy kubelet | awk -v VERSION=$${TRIMMED_KUBERNETES_VERSION} '$1~ VERSION { print $1 }' | head -n1)
+        apt-get install -y ca-certificates socat jq ebtables apt-transport-https cloud-utils prips containerd kubelet=$${RESOLVED_KUBERNETES_VERSION} kubeadm=$${RESOLVED_KUBERNETES_VERSION} kubectl=$${RESOLVED_KUBERNETES_VERSION}
       - systemctl daemon-reload
       - systemctl enable containerd
       - systemctl start containerd
-      - ping -c 3 -q {{ .controlPlaneEndpoint }} && echo OK || ip addr add {{ .controlPlaneEndpoint }} dev lo
-    postKubeadmCommands:
       - |
-        cat <<EOF >> /etc/network/interfaces
-        auto lo:0
-        iface lo:0 inet static
-          address {{ .controlPlaneEndpoint }}
-          netmask 255.255.255.255
-        EOF
-      - systemctl restart networking
+        if [ -f "/run/kubeadm/kubeadm.yaml" ]; then
+          KVVERSION=$(curl -sL https://api.github.com/repos/kube-vip/kube-vip/releases | jq -r ".[0].name")
+          ctr image pull ghcr.io/kube-vip/kube-vip:$${KVVERSION}
+          mkdir -p /etc/kubernetes/manifests/
+          ctr run --rm --net-host ghcr.io/kube-vip/kube-vip:$${KVVERSION} vip /kube-vip manifest pod --interface "lo" --vip "{{ .controlPlaneEndpoint }}" --controlplane --bgp --metal --metalKey "{{ .apiKey }}" --metalProjectID "b264ba74-f3bd-49f0-ae24-b0953765b7aa" | tee  /etc/kubernetes/manifests/kube-vip.yaml
+        fi
+      # - ping -c 3 -q {{ .controlPlaneEndpoint }} && echo OK || ip addr add {{ .controlPlaneEndpoint }} dev lo
+    postKubeadmCommands:
+      # - |
+      #   cat <<EOF >> /etc/network/interfaces
+      #   auto lo:0
+      #   iface lo:0 inet static
+      #     address {{ .controlPlaneEndpoint }}
+      #     netmask 255.255.255.255
+      #   EOF
+      # - systemctl restart networking
+      - |
+        if [ -f "/run/kubeadm/kubeadm-join-config.yaml" ]; then
+          KVVERSION=$(curl -sL https://api.github.com/repos/kube-vip/kube-vip/releases | jq -r ".[0].name")
+          ctr image pull ghcr.io/kube-vip/kube-vip:$${KVVERSION}
+          ctr run --rm --net-host ghcr.io/kube-vip/kube-vip:$${KVVERSION} vip /kube-vip manifest pod --interface "lo" --vip "{{ .controlPlaneEndpoint }}" --controlplane --bgp --metal --metalKey "{{ .apiKey }}" --metalProjectID "b264ba74-f3bd-49f0-ae24-b0953765b7aa" | tee  /etc/kubernetes/manifests/kube-vip.yaml
+        fi
       - |
         if [ -f "/run/kubeadm/kubeadm.yaml" ]; then
           export KUBECONFIG=/etc/kubernetes/admin.conf
@@ -196,14 +210,15 @@ spec:
           net.bridge.bridge-nf-call-ip6tables = 1
           EOF
         - sysctl --system
-        - apt-get -y update
-        - DEBIAN_FRONTEND=noninteractive apt-get install -y apt-transport-https curl
-        - curl -s https://packages.cloud.google.com/apt/doc/apt-key.gpg | apt-key add -
-        - echo "deb https://apt.kubernetes.io/ kubernetes-xenial main" > /etc/apt/sources.list.d/kubernetes.list
-        - apt-get update -y
-        - TRIMMED_KUBERNETES_VERSION=$(echo {{ .kubernetesVersion }} | sed 's/\./\\./g' | sed 's/^v//')
-        - RESOLVED_KUBERNETES_VERSION=$(apt-cache policy kubelet | awk -v VERSION=$${TRIMMED_KUBERNETES_VERSION} '$1~ VERSION { print $1 }' | head -n1)
-        - apt-get install -y ca-certificates socat jq ebtables apt-transport-https cloud-utils prips containerd kubelet=$${RESOLVED_KUBERNETES_VERSION} kubeadm=$${RESOLVED_KUBERNETES_VERSION} kubectl=$${RESOLVED_KUBERNETES_VERSION}
+        - |
+          apt-get -y update
+          DEBIAN_FRONTEND=noninteractive apt-get install -y apt-transport-https curl
+          curl -s https://packages.cloud.google.com/apt/doc/apt-key.gpg | apt-key add -
+          echo "deb https://apt.kubernetes.io/ kubernetes-xenial main" > /etc/apt/sources.list.d/kubernetes.list
+          apt-get update -y
+          TRIMMED_KUBERNETES_VERSION=$(echo {{ .kubernetesVersion }} | sed 's/\./\\./g' | sed 's/^v//')
+          RESOLVED_KUBERNETES_VERSION=$(apt-cache policy kubelet | awk -v VERSION=$${TRIMMED_KUBERNETES_VERSION} '$1~ VERSION { print $1 }' | head -n1)
+          apt-get install -y ca-certificates socat jq ebtables apt-transport-https cloud-utils prips containerd kubelet=$${RESOLVED_KUBERNETES_VERSION} kubeadm=$${RESOLVED_KUBERNETES_VERSION} kubectl=$${RESOLVED_KUBERNETES_VERSION}
         - systemctl daemon-reload
         - systemctl enable containerd
         - systemctl start containerd

--- a/templates/cluster-template.yaml
+++ b/templates/cluster-template.yaml
@@ -60,7 +60,6 @@ spec:
         done
         KVVERSION="${KUBE_VIP_VERSION:=v0.4.2}"
         ctr image pull ghcr.io/kube-vip/kube-vip:$${KVVERSION}
-        echo "{{ .controlPlaneEndpoint }}"
         ctr run --rm --net-host ghcr.io/kube-vip/kube-vip:$KVVERSION vip /kube-vip manifest pod \
         --interface "lo" \
         --vip "{{ .controlPlaneEndpoint }}" \

--- a/templates/cluster-template.yaml
+++ b/templates/cluster-template.yaml
@@ -74,7 +74,6 @@ spec:
         rm /run/metadata.json
     postKubeadmCommands:
       - |
-        curl -o /run/metadata.json -fsSL https://metadata.platformequinix.com/metadata
         if [ -f "/run/kubeadm/kubeadm.yaml" ]; then
           export KUBECONFIG=/etc/kubernetes/admin.conf
           export CPEM_YAML=https://github.com/equinix/cloud-provider-equinix-metal/releases/download/v3.4.0/deployment.yaml
@@ -82,7 +81,6 @@ spec:
           kubectl create secret generic -n kube-system metal-cloud-config --from-literal="$${SECRET_DATA}" || (sleep 1 && kubectl create secret generic -n kube-system metal-cloud-config --from-literal="$${SECRET_DATA}") || (sleep 1 && kubectl create secret generic -n kube-system metal-cloud-config --from-literal="$${SECRET_DATA}")
           kubectl apply -f $${CPEM_YAML} || (sleep 1 && kubectl apply -f $${CPEM_YAML}) || (sleep 1 && kubectl apply -f $${CPEM_YAML})
         fi
-        rm /run/metadata.json
 ---
 apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
 kind: PacketMachineTemplate

--- a/templates/experimental-kube-vip/kustomization.yaml
+++ b/templates/experimental-kube-vip/kustomization.yaml
@@ -55,7 +55,6 @@ patches:
             --interface "lo" \
             --vip "{{ .controlPlaneEndpoint }}" \
             --controlplane \
-            --services \
             --bgp \
             --peerAS $(cat /run/metadata.json | jq -r '.bgp_neighbors[0].peer_as') \
             --peerAddress $(cat /run/metadata.json | jq -r '.bgp_neighbors[0].peer_ips[0]') \

--- a/templates/experimental-kube-vip/kustomization.yaml
+++ b/templates/experimental-kube-vip/kustomization.yaml
@@ -20,10 +20,6 @@ patches:
       name: "${CLUSTER_NAME}-control-plane"
     spec:
       kubeadmConfigSpec:
-        joinConfiguration:
-          nodeRegistration:
-            ignorePreflightErrors:
-            - DirAvailable--etc-kubernetes-manifests
         preKubeadmCommands:
           - |
             sed -ri '/\sswap\s/s/^#?/#/' /etc/fstab

--- a/templates/experimental-kube-vip/kustomization.yaml
+++ b/templates/experimental-kube-vip/kustomization.yaml
@@ -66,7 +66,7 @@ patches:
           - |
             if [ -f "/run/kubeadm/kubeadm.yaml" ]; then
               export KUBECONFIG=/etc/kubernetes/admin.conf
-              export CPEM_YAML=https://raw.githubusercontent.com/detiber/packet-ccm/test/deploy/template/deployment.yaml
+              export CPEM_YAML=https://github.com/equinix/cloud-provider-equinix-metal/releases/download/v3.4.0/deployment.yaml
               export SECRET_DATA='cloud-sa.json=''{"apiKey": "{{ .apiKey }}","projectID": "${PROJECT_ID}", "loadbalancer": "kube-vip://", "facility": "${FACILITY}"}'''
               kubectl create secret generic -n kube-system metal-cloud-config --from-literal="$${SECRET_DATA}" || (sleep 1 && kubectl create secret generic -n kube-system metal-cloud-config --from-literal="$${SECRET_DATA}") || (sleep 1 && kubectl create secret generic -n kube-system metal-cloud-config --from-literal="$${SECRET_DATA}")
               kubectl apply -f $${CPEM_YAML} || (sleep 1 && kubectl apply -f $${CPEM_YAML}) || (sleep 1 && kubectl apply -f $${CPEM_YAML})

--- a/templates/experimental-kube-vip/kustomization.yaml
+++ b/templates/experimental-kube-vip/kustomization.yaml
@@ -13,6 +13,13 @@ patches:
         cni: "${CLUSTER_NAME}-kube-vip"
   target:
     kind: Cluster
+- patch: |-
+    apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+    kind: PacketCluster
+    metadata:
+      name: "${CLUSTER_NAME}"
+    spec:
+      vipManager: "KUBE_VIP"
 - patch: |
     kind: KubeadmControlPlane
     apiVersion: controlplane.cluster.x-k8s.io/v1beta1

--- a/templates/experimental-kube-vip/kustomization.yaml
+++ b/templates/experimental-kube-vip/kustomization.yaml
@@ -1,0 +1,110 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+resources:
+- ../cluster-template.yaml
+patches:
+- patch: |-
+    kind: Cluster
+    apiVersion: cluster.x-k8s.io/v1beta1
+    metadata:
+      name: not-used
+      labels:
+        cni: "${CLUSTER_NAME}-kube-vip"
+  target:
+    kind: Cluster
+- patch: |
+    kind: KubeadmControlPlane
+    apiVersion: controlplane.cluster.x-k8s.io/v1beta1
+    metadata:
+      name: "${CLUSTER_NAME}-control-plane"
+    spec:
+      kubeadmConfigSpec:
+        joinConfiguration:
+          nodeRegistration:
+            ignorePreflightErrors:
+            - DirAvailable--etc-kubernetes-manifests
+        preKubeadmCommands:
+          - |
+            sed -ri '/\sswap\s/s/^#?/#/' /etc/fstab
+            swapoff -a
+            mount -a
+            cat <<EOF > /etc/modules-load.d/containerd.conf
+            overlay
+            br_netfilter
+            EOF
+            modprobe overlay
+            modprobe br_netfilter
+            cat <<EOF > /etc/sysctl.d/99-kubernetes-cri.conf
+            net.bridge.bridge-nf-call-iptables  = 1
+            net.ipv4.ip_forward                 = 1
+            net.bridge.bridge-nf-call-ip6tables = 1
+            EOF
+            sysctl --system
+            apt-get -y update
+            DEBIAN_FRONTEND=noninteractive apt-get install -y apt-transport-https ca-certificates curl gnupg lsb-release linux-generic jq
+            curl -s https://packages.cloud.google.com/apt/doc/apt-key.gpg | apt-key add -
+            echo "deb https://apt.kubernetes.io/ kubernetes-xenial main" > /etc/apt/sources.list.d/kubernetes.list
+            apt-get update -y
+            TRIMMED_KUBERNETES_VERSION=$(echo {{ .kubernetesVersion }} | sed 's/\./\\\\./g' | sed 's/^v//')
+            RESOLVED_KUBERNETES_VERSION=$(apt-cache madison kubelet | awk -v VERSION=$${TRIMMED_KUBERNETES_VERSION} '$3~ VERSION { print $3 }' | head -n1)
+            DEBIAN_FRONTEND=noninteractive apt-get install -y containerd kubelet=$${RESOLVED_KUBERNETES_VERSION} kubeadm=$${RESOLVED_KUBERNETES_VERSION} kubectl=$${RESOLVED_KUBERNETES_VERSION}
+            curl -o /run/metadata.json -fsSL https://metadata.platformequinix.com/metadata
+            for i in $(cat /run/metadata.json | jq -r '.bgp_neighbors[0].peer_ips[]'); do
+              ip route add $i via $(cat /run/metadata.json | jq -r '.network.addresses[] | select(.public == false and .address_family == 4) | .gateway')
+            done
+            KVVERSION="${KUBE_VIP_VERSION:=v0.4.2}"
+            ctr image pull ghcr.io/kube-vip/kube-vip:$${KVVERSION}
+            ctr run --rm --net-host ghcr.io/kube-vip/kube-vip:$KVVERSION vip /kube-vip manifest pod \
+            --interface "lo" \
+            --vip "{{ .controlPlaneEndpoint }}" \
+            --controlplane \
+            --services \
+            --bgp \
+            --peerAS $(cat /run/metadata.json | jq -r '.bgp_neighbors[0].peer_as') \
+            --peerAddress $(cat /run/metadata.json | jq -r '.bgp_neighbors[0].peer_ips[0]') \
+            --localAS $(cat /run/metadata.json | jq -r '.bgp_neighbors[0].customer_as') \
+            --bgpRouterID $(cat /run/metadata.json | jq -r '.bgp_neighbors[0].customer_ip') > /etc/kubernetes/manifests/vip.yaml
+            rm /run/metadata.json
+        postKubeadmCommands:
+          - |
+            if [ -f "/run/kubeadm/kubeadm.yaml" ]; then
+              export KUBECONFIG=/etc/kubernetes/admin.conf
+              export CPEM_YAML=https://raw.githubusercontent.com/detiber/packet-ccm/test/deploy/template/deployment.yaml
+              export SECRET_DATA='cloud-sa.json=''{"apiKey": "{{ .apiKey }}","projectID": "${PROJECT_ID}", "loadbalancer": "kube-vip://", "facility": "${FACILITY}"}'''
+              kubectl create secret generic -n kube-system metal-cloud-config --from-literal="$${SECRET_DATA}" || (sleep 1 && kubectl create secret generic -n kube-system metal-cloud-config --from-literal="$${SECRET_DATA}") || (sleep 1 && kubectl create secret generic -n kube-system metal-cloud-config --from-literal="$${SECRET_DATA}")
+              kubectl apply -f $${CPEM_YAML} || (sleep 1 && kubectl apply -f $${CPEM_YAML}) || (sleep 1 && kubectl apply -f $${CPEM_YAML})
+            fi
+- patch: |
+    kind: KubeadmConfigTemplate
+    apiVersion: bootstrap.cluster.x-k8s.io/v1beta1
+    metadata:
+      name: "${CLUSTER_NAME}-worker-a"
+    spec:
+      template:
+        spec:
+          preKubeadmCommands:
+            - |
+              sed -ri '/\sswap\s/s/^#?/#/' /etc/fstab
+              swapoff -a
+              mount -a
+              cat <<EOF > /etc/modules-load.d/containerd.conf
+              overlay
+              br_netfilter
+              EOF
+              modprobe overlay
+              modprobe br_netfilter
+              cat <<EOF > /etc/sysctl.d/99-kubernetes-cri.conf
+              net.bridge.bridge-nf-call-iptables  = 1
+              net.ipv4.ip_forward                 = 1
+              net.bridge.bridge-nf-call-ip6tables = 1
+              EOF
+              sysctl --system
+              apt-get -y update
+              DEBIAN_FRONTEND=noninteractive apt-get install -y apt-transport-https ca-certificates curl gnupg lsb-release linux-generic jq
+              curl -s https://packages.cloud.google.com/apt/doc/apt-key.gpg | apt-key add -
+              echo "deb https://apt.kubernetes.io/ kubernetes-xenial main" > /etc/apt/sources.list.d/kubernetes.list
+              apt-get update -y
+              TRIMMED_KUBERNETES_VERSION=$(echo {{ .kubernetesVersion }} | sed 's/\./\\\\./g' | sed 's/^v//')
+              RESOLVED_KUBERNETES_VERSION=$(apt-cache madison kubelet | awk -v VERSION=$${TRIMMED_KUBERNETES_VERSION} '$3~ VERSION { print $3 }' | head -n1)
+              DEBIAN_FRONTEND=noninteractive apt-get install -y containerd kubelet=$${RESOLVED_KUBERNETES_VERSION} kubeadm=$${RESOLVED_KUBERNETES_VERSION} kubectl=$${RESOLVED_KUBERNETES_VERSION}


### PR DESCRIPTION
Replacement of: https://github.com/detiber/cluster-api-provider-packet/pull/65.
What this PR does / why we need it:
This replaces the binding of an elastic IP to one of the control plane nodes with deploying kube-vip and having it load balance the Kubernetes API between the various control plane nodes.

