### PR TITLE
Include IP assigmenets when reconciling VIP ips

### DIFF
--- a/pkg/cloud/packet/client.go
+++ b/pkg/cloud/packet/client.go
@@ -303,6 +303,7 @@ func (p *Client) GetIPByClusterIdentifier(namespace, name, projectID string) (pa
 	var reservedIP packngo.IPAddressReservation
 
 	listOpts := &packngo.ListOptions{}
+	listOpts = listOpts.Including("assignments", "assignments.assigned_to")
 	reservedIPs, _, err := p.ProjectIPs.List(projectID, listOpts)
 	if err != nil {
 		return reservedIP, err


### PR DESCRIPTION
on CPEM clusters.

Signed-off-by: Chris Privitere <23177737+cprivitere@users.noreply.github.com>

<!-- please add a icon to the title of this PR (see https://sigs.k8s.io/cluster-api/VERSIONING.md), and delete this line and similar ones -->
<!-- the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, minor or feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🏃 (:running:, other) -->

**What this PR does / why we need it**:

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #
