### PR TITLE
:sparkles: Change to c3.medium.x86 plans for testing.

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -188,8 +188,8 @@ jobs:
         SKIP_IMAGE_BUILD: "1"
         MANIFEST_PATH: "../../../out/release"
         FACILITY: da6
-        CONTROLPLANE_NODE_TYPE: t3.small.x86
-        WORKER_NODE_TYPE: t3.small.x86
+        CONTROLPLANE_NODE_TYPE: c3.medium.x86
+        WORKER_NODE_TYPE: c3.medium.x86
         GINKGO_NODES: "1"
       run: ./scripts/ci-e2e-capi-quickstart.sh
     - name: Upload artifact
@@ -244,8 +244,8 @@ jobs:
         SKIP_IMAGE_BUILD: "1"
         MANIFEST_PATH: "../../../out/release"
         FACILITY: da6
-        CONTROLPLANE_NODE_TYPE: t3.small.x86
-        WORKER_NODE_TYPE: t3.small.x86
+        CONTROLPLANE_NODE_TYPE: c3.medium.x86
+        WORKER_NODE_TYPE: c3.medium.x86
         GINKGO_NODES: "1"
       run: ./scripts/ci-e2e-capi.sh
     - name: Upload artifact
@@ -300,8 +300,8 @@ jobs:
         SKIP_IMAGE_BUILD: "1"
         MANIFEST_PATH: "../../../out/release"
         FACILITY: da6
-        CONTROLPLANE_NODE_TYPE: t3.small.x86
-        WORKER_NODE_TYPE: t3.small.x86
+        CONTROLPLANE_NODE_TYPE: c3.medium.x86
+        WORKER_NODE_TYPE: c3.medium.x86
         GINKGO_NODES: "1"
       run: ./scripts/ci-e2e-capi-conformance.sh
     - name: Upload artifact
@@ -356,8 +356,8 @@ jobs:
         SKIP_IMAGE_BUILD: "1"
         MANIFEST_PATH: "../../../out/release"
         FACILITY: da6
-        CONTROLPLANE_NODE_TYPE: t3.small.x86
-        WORKER_NODE_TYPE: t3.small.x86
+        CONTROLPLANE_NODE_TYPE: c3.medium.x86
+        WORKER_NODE_TYPE: c3.medium.x86
         GINKGO_NODES: "1"
       run: ./scripts/ci-e2e-capi-management-upgrade.sh
     - name: Upload artifact
@@ -412,8 +412,8 @@ jobs:
         SKIP_IMAGE_BUILD: "1"
         MANIFEST_PATH: "../../../out/release"
         FACILITY: da6
-        CONTROLPLANE_NODE_TYPE: t3.small.x86
-        WORKER_NODE_TYPE: t3.small.x86
+        CONTROLPLANE_NODE_TYPE: c3.medium.x86
+        WORKER_NODE_TYPE: c3.medium.x86
         GINKGO_NODES: "1"
       run: ./scripts/ci-e2e-capi-workload-upgrade.sh
     - name: Upload artifact


### PR DESCRIPTION
Signed-off-by: Chris Privitere <23177737+cprivitere@users.noreply.github.com>

**What this PR does / why we need it**:
The testing account can't use t3.small instances so switch to c3.medium.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
