### PR TITLE
:sparkles: Add the workflow_dispatch option

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -5,6 +5,7 @@ on:
     - main
   schedule:
     - cron: "0 */4 * * *" # TODO: Run every 4 hours to soak test, should be less frequent before merge (weekly/daily/???)
+  workflow_dispatch:
 env:
   IMAGE_NAME: cluster-api-provider-packet
   GHCR_REGISTRY: ghcr.io/${{ github.repository_owner }}


### PR DESCRIPTION
Signed-off-by: Chris Privitere <23177737+cprivitere@users.noreply.github.com>

**What this PR does / why we need it**:
Want to be able to manually kick off CI runs while troubleshooting.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Part of #360 