### PR TITLE
:sparkles: Use da11 as that's where machines are.

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -188,7 +188,7 @@ jobs:
         E2E_CONF_FILE_SOURCE: "${{ github.workspace }}/test/e2e/config/packet-ci-actions.yaml"
         SKIP_IMAGE_BUILD: "1"
         MANIFEST_PATH: "../../../out/release"
-        FACILITY: da6
+        FACILITY: da11
         CONTROLPLANE_NODE_TYPE: c3.medium.x86
         WORKER_NODE_TYPE: c3.medium.x86
         GINKGO_NODES: "1"
@@ -244,7 +244,7 @@ jobs:
         E2E_CONF_FILE_SOURCE: "${{ github.workspace }}/test/e2e/config/packet-ci-actions.yaml"
         SKIP_IMAGE_BUILD: "1"
         MANIFEST_PATH: "../../../out/release"
-        FACILITY: da6
+        FACILITY: da11
         CONTROLPLANE_NODE_TYPE: c3.medium.x86
         WORKER_NODE_TYPE: c3.medium.x86
         GINKGO_NODES: "1"
@@ -300,7 +300,7 @@ jobs:
         E2E_CONF_FILE_SOURCE: "${{ github.workspace }}/test/e2e/config/packet-ci-actions.yaml"
         SKIP_IMAGE_BUILD: "1"
         MANIFEST_PATH: "../../../out/release"
-        FACILITY: da6
+        FACILITY: da11
         CONTROLPLANE_NODE_TYPE: c3.medium.x86
         WORKER_NODE_TYPE: c3.medium.x86
         GINKGO_NODES: "1"
@@ -356,7 +356,7 @@ jobs:
         E2E_CONF_FILE_SOURCE: "${{ github.workspace }}/test/e2e/config/packet-ci-actions.yaml"
         SKIP_IMAGE_BUILD: "1"
         MANIFEST_PATH: "../../../out/release"
-        FACILITY: da6
+        FACILITY: da11
         CONTROLPLANE_NODE_TYPE: c3.medium.x86
         WORKER_NODE_TYPE: c3.medium.x86
         GINKGO_NODES: "1"
@@ -412,7 +412,7 @@ jobs:
         E2E_CONF_FILE_SOURCE: "${{ github.workspace }}/test/e2e/config/packet-ci-actions.yaml"
         SKIP_IMAGE_BUILD: "1"
         MANIFEST_PATH: "../../../out/release"
-        FACILITY: da6
+        FACILITY: da11
         CONTROLPLANE_NODE_TYPE: c3.medium.x86
         WORKER_NODE_TYPE: c3.medium.x86
         GINKGO_NODES: "1"


### PR DESCRIPTION
Signed-off-by: Chris Privitere <23177737+cprivitere@users.noreply.github.com>

**What this PR does / why we need it**:
Switch the CI to use machines in the DA11 facility. DA6 does not have the machine type we want.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
For #360
