### PR TITLE
:sparkles: Add User-Agent support for Equinix Metal Calls

### DIFF
--- a/cmd/ci-clean/main.go
+++ b/cmd/ci-clean/main.go
@@ -27,6 +27,7 @@ import (
 	"github.com/packethost/packngo"
 	"github.com/spf13/cobra"
 	kerrors "k8s.io/apimachinery/pkg/util/errors"
+
 	"sigs.k8s.io/cluster-api-provider-packet/version"
 )
 

--- a/cmd/ci-clean/main.go
+++ b/cmd/ci-clean/main.go
@@ -27,6 +27,7 @@ import (
 	"github.com/packethost/packngo"
 	"github.com/spf13/cobra"
 	kerrors "k8s.io/apimachinery/pkg/util/errors"
+	"sigs.k8s.io/cluster-api-provider-packet/version"
 )
 
 const (
@@ -64,6 +65,7 @@ func main() {
 
 func cleanup(metalAuthToken, metalProjectID string) error {
 	metalClient := packngo.NewClientWithAuth("capp-e2e", metalAuthToken, nil)
+	metalClient.UserAgent = fmt.Sprintf("capp-e2e/%s %s", version.Get(), metalClient.UserAgent)
 	listOpts := &packngo.ListOptions{}
 	var errs []error
 

--- a/pkg/cloud/packet/client.go
+++ b/pkg/cloud/packet/client.go
@@ -33,11 +33,13 @@ import (
 
 	infrav1 "sigs.k8s.io/cluster-api-provider-packet/api/v1beta1"
 	"sigs.k8s.io/cluster-api-provider-packet/pkg/cloud/packet/scope"
+	"sigs.k8s.io/cluster-api-provider-packet/version"
 )
 
 const (
 	apiTokenVarName = "PACKET_API_KEY" //nolint:gosec
 	clientName      = "CAPP-v1beta1"
+	clientUAFormat  = "cluster-api-provider-packet/%s %s"
 	ipxeOS          = "custom_ipxe"
 	envVarLocalASN  = "METAL_LOCAL_ASN"
 	envVarBGPPass   = "METAL_BGP_PASS" //nolint:gosec
@@ -61,7 +63,10 @@ func NewClient(packetAPIKey string) *Client {
 	token := strings.TrimSpace(packetAPIKey)
 
 	if token != "" {
-		return &Client{packngo.NewClientWithAuth(clientName, token, nil)}
+		metalClient := &Client{packngo.NewClientWithAuth(clientName, token, nil)}
+		metalClient.UserAgent = fmt.Sprintf(clientUAFormat, version.Get(), metalClient.UserAgent)
+
+		return metalClient
 	}
 
 	return nil
@@ -134,7 +139,7 @@ func (p *Client) NewDevice(ctx context.Context, req CreateDeviceRequest) (*packn
 	userData = stringWriter.String()
 
 	// Allow to override the facility for each PacketMachineTemplate
-	var facility = req.MachineScope.PacketCluster.Spec.Facility
+	facility := req.MachineScope.PacketCluster.Spec.Facility
 	if req.MachineScope.PacketMachine.Spec.Facility != "" {
 		facility = req.MachineScope.PacketMachine.Spec.Facility
 	}

--- a/test/e2e/common_test.go
+++ b/test/e2e/common_test.go
@@ -1,3 +1,4 @@
+//go:build e2e
 // +build e2e
 
 /*
@@ -40,6 +41,7 @@ import (
 	"k8s.io/client-go/tools/clientcmd"
 	"k8s.io/client-go/tools/clientcmd/api"
 	"sigs.k8s.io/cluster-api-provider-packet/pkg/cloud/packet"
+	"sigs.k8s.io/cluster-api-provider-packet/version"
 	clusterv1old "sigs.k8s.io/cluster-api/api/v1alpha3"
 	clusterv1 "sigs.k8s.io/cluster-api/api/v1beta1"
 	"sigs.k8s.io/cluster-api/test/framework"
@@ -208,7 +210,8 @@ func (w *wrappedClusterProxy) Dispose(ctx context.Context) {
 	metalAuthToken := os.Getenv(AuthTokenEnvVar)
 	metalProjectID := os.Getenv(ProjectIDEnvVar)
 	if metalAuthToken != "" && metalProjectID != "" {
-		metal := packet.NewClient(metalAuthToken)
+		metal := packet.NewClientWithAuth(clientName, metalAuthToken)
+		metal.UserAgent = fmt.Sprintf("capp-e2e/%s %s", version.Version, metalClient.UserAgent)
 
 		Eventually(func(g Gomega) {
 			clusterNames := w.clusterNames.UnsortedList()

--- a/test/e2e/suite_test.go
+++ b/test/e2e/suite_test.go
@@ -1,3 +1,4 @@
+//go:build e2e
 // +build e2e
 
 /*
@@ -43,6 +44,7 @@ import (
 	"sigs.k8s.io/cluster-api/util"
 
 	"sigs.k8s.io/cluster-api-provider-packet/api/v1beta1"
+	"sigs.k8s.io/cluster-api-provider-packet/version"
 )
 
 const (
@@ -178,6 +180,7 @@ var _ = SynchronizedAfterSuite(func() {
 		if metalAuthToken != "" && sshKeyID != "" {
 			By("Cleaning up the generated SSH Key")
 			metalClient := packngo.NewClientWithAuth("capp-e2e", metalAuthToken, nil)
+			metalClient.UserAgent = fmt.Sprintf("capp-e2e/%s %s", version.Version, metalClient.UserAgent)
 			_, err := metalClient.SSHKeys.Delete(sshKeyID)
 			Expect(err).NotTo(HaveOccurred())
 		}
@@ -286,6 +289,7 @@ func generateSSHKey() (string, string) {
 	Expect(err).NotTo(HaveOccurred())
 
 	metalClient := packngo.NewClientWithAuth("capp-e2e", metalAuthToken, nil)
+	metalClient.UserAgent = fmt.Sprintf("capp-e2e/%s %s", version.Version, metalClient.UserAgent)
 	res, _, err := metalClient.SSHKeys.Create(
 		&packngo.SSHKeyCreateRequest{
 			Label: fmt.Sprintf("capp-e2e-%s", util.RandomString(6)),

--- a/version/version.go
+++ b/version/version.go
@@ -1,9 +1,12 @@
 /*
 Copyright 2022 The Kubernetes Authors.
+
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
+
     http://www.apache.org/licenses/LICENSE-2.0
+
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,
 WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.

--- a/version/version.go
+++ b/version/version.go
@@ -1,0 +1,65 @@
+/*
+Copyright 2022 The Kubernetes Authors.
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package version
+
+import (
+	"fmt"
+	"runtime"
+
+	"github.com/packethost/packngo"
+)
+
+var (
+	gitMajor     string // major version, always numeric
+	gitMinor     string // minor version, numeric possibly followed by "+"
+	gitVersion   string // semantic version, derived by build scripts
+	gitCommit    string // sha1 from git, output of $(git rev-parse HEAD)
+	gitTreeState string // state of git tree, either "clean" or "dirty"
+	buildDate    string // build date in ISO8601 format, output of $(date -u +'%Y-%m-%dT%H:%M:%SZ')
+)
+
+// Info contains all version-related information.
+type Info struct {
+	Major           string `json:"major,omitempty"`
+	Minor           string `json:"minor,omitempty"`
+	GitVersion      string `json:"gitVersion,omitempty"`
+	GitCommit       string `json:"gitCommit,omitempty"`
+	GitTreeState    string `json:"gitTreeState,omitempty"`
+	BuildDate       string `json:"buildDate,omitempty"`
+	GoVersion       string `json:"goVersion,omitempty"`
+	Compiler        string `json:"compiler,omitempty"`
+	Platform        string `json:"platform,omitempty"`
+	MetalSdkVersion string `json:"metalSdkVersion,omitempty"`
+}
+
+// Get returns version info initialized from defaults and the runtime environment.
+func Get() Info {
+	return Info{
+		Major:           gitMajor,
+		Minor:           gitMinor,
+		GitVersion:      gitVersion,
+		GitCommit:       gitCommit,
+		GitTreeState:    gitTreeState,
+		BuildDate:       buildDate,
+		GoVersion:       runtime.Version(),
+		Compiler:        runtime.Compiler,
+		Platform:        fmt.Sprintf("%s/%s", runtime.GOOS, runtime.GOARCH),
+		MetalSdkVersion: packngo.Version,
+	}
+}
+
+// String returns version info in a human-friendly format.
+func (info Info) String() string {
+	return info.GitVersion
+}


### PR DESCRIPTION
Signed-off-by: Chris Privitere <23177737+cprivitere@users.noreply.github.com>

Add user-agent support to the equinix metal api calls so we can do analytics and tell how many people are using what version of CAPP.
