### PR TITLE
:sparkles: bump cluster-api to 1.1.3

### DIFF
--- a/test/e2e/config/packet-ci-actions.yaml
+++ b/test/e2e/config/packet-ci-actions.yaml
@@ -31,8 +31,8 @@ providers:
         new: --metrics-addr=:8080
     files:
     - sourcePath: "../data/shared/v1beta1/metadata.yaml"
-  - name: v1.1.2 # latest published release in the v1beta1 series
-    value: "https://github.com/kubernetes-sigs/cluster-api/releases/download/v1.1.2/core-components.yaml"
+  - name: v1.1.3 # latest published release in the v1beta1 series
+    value: "https://github.com/kubernetes-sigs/cluster-api/releases/download/v1.1.3/core-components.yaml"
     type: "url"
     contract: v1beta1
     replacements:
@@ -62,8 +62,8 @@ providers:
         new: --metrics-addr=:8080
     files:
     - sourcePath: "../data/shared/v1beta1/metadata.yaml"
-  - name: v1.1.2 # latest published release in the v1beta1 series
-    value: "https://github.com/kubernetes-sigs/cluster-api/releases/download/v1.1.2/bootstrap-components.yaml"
+  - name: v1.1.3 # latest published release in the v1beta1 series
+    value: "https://github.com/kubernetes-sigs/cluster-api/releases/download/v1.1.3/bootstrap-components.yaml"
     type: "url"
     contract: v1beta1
     replacements:
@@ -93,8 +93,8 @@ providers:
         new: --metrics-addr=:8080
     files:
     - sourcePath: "../data/shared/v1beta1/metadata.yaml"
-  - name: v1.1.2 # latest published release in the v1beta1 series; this is used for v1beta1 --> main clusterctl upgrades test only.
-    value: "https://github.com/kubernetes-sigs/cluster-api/releases/download/v1.1.2/control-plane-components.yaml"
+  - name: v1.1.3 # latest published release in the v1beta1 series; this is used for v1beta1 --> main clusterctl upgrades test only.
+    value: "https://github.com/kubernetes-sigs/cluster-api/releases/download/v1.1.3/control-plane-components.yaml"
     type: "url"
     contract: v1beta1
     replacements:
@@ -115,6 +115,17 @@ providers:
       - sourcePath: "../data/v1alpha3/cluster-template-packet-ccm.yaml"
       - sourcePath: "../data/v1alpha3/cluster-template-cpem.yaml"
   - name: v0.5.0
+    value: "${MANIFEST_PATH:=..}/infrastructure-components.yaml"
+    type: "url"
+    contract: v1beta1
+    files:
+    - sourcePath: "${MANIFEST_PATH:=..}/metadata.yaml"
+    - sourcePath: "../data/v1beta1/cluster-template.yaml"
+    - sourcePath: "../data/v1beta1/cluster-template-kcp-scale-in.yaml"
+    - sourcePath: "../data/v1beta1/cluster-template-node-drain.yaml"
+    - sourcePath: "../data/v1beta1/cluster-template-md-remediation.yaml"
+    - sourcePath: "../data/v1beta1/cluster-template-kcp-remediation.yaml"
+  - name: v1.1.99 # next; use manifest from source files
     value: "${MANIFEST_PATH:=..}/infrastructure-components.yaml"
     type: "url"
     contract: v1beta1

--- a/test/e2e/config/packet-ci.yaml
+++ b/test/e2e/config/packet-ci.yaml
@@ -31,8 +31,8 @@ providers:
         new: --metrics-addr=:8080
     files:
     - sourcePath: "../data/shared/v1beta1/metadata.yaml"
-  - name: v1.1.2 # latest published release in the v1beta1 series
-    value: "https://github.com/kubernetes-sigs/cluster-api/releases/download/v1.1.2/core-components.yaml"
+  - name: v1.1.3 # latest published release in the v1beta1 series
+    value: "https://github.com/kubernetes-sigs/cluster-api/releases/download/v1.1.3/core-components.yaml"
     type: "url"
     contract: v1beta1
     replacements:
@@ -62,8 +62,8 @@ providers:
         new: --metrics-addr=:8080
     files:
     - sourcePath: "../data/shared/v1beta1/metadata.yaml"
-  - name: v1.1.2 # latest published release in the v1beta1 series
-    value: "https://github.com/kubernetes-sigs/cluster-api/releases/download/v1.1.2/bootstrap-components.yaml"
+  - name: v1.1.3 # latest published release in the v1beta1 series
+    value: "https://github.com/kubernetes-sigs/cluster-api/releases/download/v1.1.3/bootstrap-components.yaml"
     type: "url"
     contract: v1beta1
     replacements:
@@ -93,8 +93,8 @@ providers:
         new: --metrics-addr=:8080
     files:
     - sourcePath: "../data/shared/v1beta1/metadata.yaml"
-  - name: v1.1.2 # latest published release in the v1beta1 series; this is used for v1beta1 --> main clusterctl upgrades test only.
-    value: "https://github.com/kubernetes-sigs/cluster-api/releases/download/v1.1.2/control-plane-components.yaml"
+  - name: v1.1.3 # latest published release in the v1beta1 series; this is used for v1beta1 --> main clusterctl upgrades test only.
+    value: "https://github.com/kubernetes-sigs/cluster-api/releases/download/v1.1.3/control-plane-components.yaml"
     type: "url"
     contract: v1beta1
     replacements:
@@ -106,7 +106,7 @@ providers:
 - name: packet
   type: InfrastructureProvider
   versions:
-  - name: v0.3.11
+  - name: v0.3.11 #latest in the v1alpha1 series
     value: "https://github.com/kubernetes-sigs/cluster-api-provider-packet/releases/download/v0.3.11/infrastructure-components.yaml"
     type: "url"
     contract: v1alpha3
@@ -114,7 +114,20 @@ providers:
       # Add cluster templates
       - sourcePath: "../data/v1alpha3/cluster-template-packet-ccm.yaml"
       - sourcePath: "../data/v1alpha3/cluster-template-cpem.yaml"
-  - name: v0.5.0
+  - name: v0.5.0 #latest in the v1beta1 series
+    value: "../../../config/default"
+    replacements:
+    - old: "image: .*/cluster-api-provider-packet:.*"
+      new: "image: ${REGISTRY:=ghcr.io}/${IMAGE_NAME:=kubernetes-sigs/cluster-api-provider-packet}:${TAG:=e2e}"
+    contract: v1beta1
+    files:
+    - sourcePath: "../../../metadata.yaml"
+    - sourcePath: "../data/v1beta1/cluster-template.yaml"
+    - sourcePath: "../data/v1beta1/cluster-template-kcp-scale-in.yaml"
+    - sourcePath: "../data/v1beta1/cluster-template-node-drain.yaml"
+    - sourcePath: "../data/v1beta1/cluster-template-md-remediation.yaml"
+    - sourcePath: "../data/v1beta1/cluster-template-kcp-remediation.yaml"
+  - name: v1.1.99 # next; use manifest from source files
     value: "../../../config/default"
     replacements:
     - old: "image: .*/cluster-api-provider-packet:.*"


### PR DESCRIPTION
Add 1.1.99 section for tilt

Signed-off-by: Chris Privitere <23177737+cprivitere@users.noreply.github.com>

**What this PR does / why we need it**:
This bumps the cluster-api module version used by tests to 1.1.3, which is what we currently support.
This also adds a 1.1.99 section (aka the "Next") version, for testing with things like tilt that want to use the current source files.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #375 
