### PR TITLE
:sparkles: Remove-capp-e2e-tags

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -148,7 +148,6 @@ E2E_DIR ?= $(REPO_ROOT)/test/e2e
 KUBETEST_CONF_PATH ?= $(abspath $(E2E_DIR)/data/kubetest/conformance.yaml)
 E2E_CONF_FILE_SOURCE ?= $(E2E_DIR)/config/packet-ci.yaml
 E2E_CONF_FILE ?= $(E2E_DIR)/config/packet-ci-envsubst.yaml
-E2E_LD_FLAGS ?= "-X 'sigs.k8s.io/cluster-api-provider-packet/pkg/cloud/packet.clientName=capp-e2e' -X 'sigs.k8s.io/cluster-api-provider-packet/pkg/cloud/packet.clientUAFormat=capp-e2e/%s %s'"
 
 .PHONY: $(E2E_CONF_FILE)
 $(E2E_CONF_FILE): $(ENVSUBST) $(E2E_CONF_FILE_SOURCE)
@@ -160,7 +159,6 @@ run-e2e-tests: $(KUBECTL) $(KUSTOMIZE) $(KIND) $(GINKGO) $(E2E_CONF_FILE) e2e-te
 	$(MAKE) set-manifest-image MANIFEST_IMG=$(REGISTRY)/$(IMAGE_NAME) MANIFEST_TAG=$(TAG)
 	$(MAKE) set-manifest-pull-policy PULL_POLICY=IfNotPresent
 	cd test/e2e; time $(GINKGO) -v -trace -progress -v -tags=e2e \
-		-ldflags $(E2E_LD_FLAGS) \
 		--randomizeAllSpecs -race $(GINKGO_ADDITIONAL_ARGS) \
 		-focus=$(GINKGO_FOCUS) -skip=$(GINKGO_SKIP) \
 		-nodes=$(GINKGO_NODES) --noColor=$(GINKGO_NOCOLOR) \

--- a/cmd/ci-clean/main.go
+++ b/cmd/ci-clean/main.go
@@ -27,8 +27,7 @@ import (
 	"github.com/packethost/packngo"
 	"github.com/spf13/cobra"
 	kerrors "k8s.io/apimachinery/pkg/util/errors"
-
-	"sigs.k8s.io/cluster-api-provider-packet/version"
+	"sigs.k8s.io/cluster-api-provider-packet/pkg/cloud/packet"
 )
 
 const (
@@ -65,8 +64,7 @@ func main() {
 }
 
 func cleanup(metalAuthToken, metalProjectID string) error {
-	metalClient := packngo.NewClientWithAuth("capp-e2e", metalAuthToken, nil)
-	metalClient.UserAgent = fmt.Sprintf("capp-e2e/%s %s", version.Get(), metalClient.UserAgent)
+	metalClient := packet.NewClient(metalAuthToken)
 	listOpts := &packngo.ListOptions{}
 	var errs []error
 

--- a/cmd/ci-clean/main.go
+++ b/cmd/ci-clean/main.go
@@ -27,6 +27,7 @@ import (
 	"github.com/packethost/packngo"
 	"github.com/spf13/cobra"
 	kerrors "k8s.io/apimachinery/pkg/util/errors"
+
 	"sigs.k8s.io/cluster-api-provider-packet/pkg/cloud/packet"
 )
 
@@ -98,7 +99,7 @@ func cleanup(metalAuthToken, metalProjectID string) error {
 	return kerrors.NewAggregate(errs)
 }
 
-func deleteDevices(metalClient *packngo.Client, devices []packngo.Device) error {
+func deleteDevices(metalClient *packet.Client, devices []packngo.Device) error {
 	var errs []error
 
 	for _, d := range devices {
@@ -119,7 +120,7 @@ func deleteDevices(metalClient *packngo.Client, devices []packngo.Device) error 
 	return kerrors.NewAggregate(errs)
 }
 
-func deleteIPs(metalClient *packngo.Client, ips []packngo.IPAddressReservation) error {
+func deleteIPs(metalClient *packet.Client, ips []packngo.IPAddressReservation) error {
 	var errs []error
 
 	for _, ip := range ips {
@@ -147,7 +148,7 @@ func deleteIPs(metalClient *packngo.Client, ips []packngo.IPAddressReservation) 
 	return kerrors.NewAggregate(errs)
 }
 
-func deleteKeys(metalClient *packngo.Client, keys []packngo.SSHKey) error {
+func deleteKeys(metalClient *packet.Client, keys []packngo.SSHKey) error {
 	var errs []error
 
 	for _, k := range keys {

--- a/pkg/cloud/packet/client.go
+++ b/pkg/cloud/packet/client.go
@@ -81,7 +81,7 @@ func GetClient() (*Client, error) {
 }
 
 func (p *Client) GetDevice(deviceID string) (*packngo.Device, error) {
-	dev, _, err := p.Client.Devices.Get(deviceID, nil)
+	dev, _, err := p.Devices.Get(deviceID, nil)
 	return dev, err
 }
 
@@ -121,7 +121,7 @@ func (p *Client) NewDevice(ctx context.Context, req CreateDeviceRequest) (*packn
 
 	if req.MachineScope.IsControlPlane() {
 		// control plane machines should get the API key injected
-		userDataValues["apiKey"] = p.Client.APIKey
+		userDataValues["apiKey"] = p.APIKey
 
 		if req.ControlPlaneEndpoint != "" {
 			userDataValues["controlPlaneEndpoint"] = req.ControlPlaneEndpoint
@@ -160,7 +160,7 @@ func (p *Client) NewDevice(ctx context.Context, req CreateDeviceRequest) (*packn
 
 	// If there are no reservationIDs to process, go ahead and return early
 	if len(reservationIDs) == 0 {
-		dev, _, err := p.Client.Devices.Create(serverCreateOpts)
+		dev, _, err := p.Devices.Create(serverCreateOpts)
 		return dev, err
 	}
 
@@ -171,7 +171,7 @@ func (p *Client) NewDevice(ctx context.Context, req CreateDeviceRequest) (*packn
 
 	for _, resID := range reservationIDs {
 		serverCreateOpts.HardwareReservationID = resID
-		dev, _, err := p.Client.Devices.Create(serverCreateOpts)
+		dev, _, err := p.Devices.Create(serverCreateOpts)
 		if err != nil {
 			lastErr = err
 			continue

--- a/pkg/cloud/packet/client.go
+++ b/pkg/cloud/packet/client.go
@@ -37,6 +37,8 @@ import (
 )
 
 const (
+	clientName      = "CAPP-v1beta1"
+	clientUAFormat  = "cluster-api-provider-packet/%s %s"
 	apiTokenVarName = "PACKET_API_KEY" //nolint:gosec
 	ipxeOS          = "custom_ipxe"
 	envVarLocalASN  = "METAL_LOCAL_ASN"
@@ -45,8 +47,6 @@ const (
 )
 
 var (
-	clientName                     = "CAPP-v1beta1"
-	clientUAFormat                 = "cluster-api-provider-packet/%s %s"
 	ErrControlPlanEndpointNotFound = errors.New("control plane not found")
 	ErrElasticIPQuotaExceeded      = errors.New("could not create an Elastic IP due to quota limits on the account, please contact Equinix Metal support")
 	ErrInvalidIP                   = errors.New("invalid IP")

--- a/pkg/cloud/packet/client.go
+++ b/pkg/cloud/packet/client.go
@@ -37,8 +37,6 @@ import (
 )
 
 const (
-	clientName      = "CAPP-v1beta1"
-	clientUAFormat  = "cluster-api-provider-packet/%s %s"
 	apiTokenVarName = "PACKET_API_KEY" //nolint:gosec
 	ipxeOS          = "custom_ipxe"
 	envVarLocalASN  = "METAL_LOCAL_ASN"
@@ -47,6 +45,8 @@ const (
 )
 
 var (
+	clientName                     = "CAPP-v1beta1"
+	clientUAFormat                 = "cluster-api-provider-packet/%s %s"
 	ErrControlPlanEndpointNotFound = errors.New("control plane not found")
 	ErrElasticIPQuotaExceeded      = errors.New("could not create an Elastic IP due to quota limits on the account, please contact Equinix Metal support")
 	ErrInvalidIP                   = errors.New("invalid IP")


### PR DESCRIPTION
Signed-off-by: Chris Privitere <23177737+cprivitere@users.noreply.github.com>

**What this PR does / why we need it**:
The capp e2e testing useragent overrides via ldflags resulted in an akward situation. The few calls to equinix metal done by the e2e test code itself had the correct useragent, but the majority of calls via the manager did not, due to the CI framework pre-building the manager and thus not gettting any of the ldflag overrides from the E2E tests.

Current thinking is to add an Environment variable in the future which can add more UserAgent information. #385
