### PR TITLE
 ✨ Set up default environment for kubectl, crictl, etc.

### DIFF
--- a/templates/cluster-template-crs-cni.yaml
+++ b/templates/cluster-template-crs-cni.yaml
@@ -160,7 +160,6 @@ spec:
       if [ -f "/run/kubeadm/kubeadm.yaml" ]; then
         export KUBECONFIG=/etc/kubernetes/admin.conf
         mkdir -p /root/.kube && cp -f $${KUBECONFIG} /root/.kube/config
-        echo "export KUBECONFIG=/etc/kubernetes/admin.conf" >> /root/.bashrc
         echo "source <(kubectl completion bash)" >> /root/.bashrc
         echo "alias k=kubectl" >> /root/.bashrc
         echo "complete -o default -F __start_kubectl k" >> /root/.bashrc

--- a/templates/cluster-template-crs-cni.yaml
+++ b/templates/cluster-template-crs-cni.yaml
@@ -30,7 +30,7 @@ spec:
             cloud-provider: external
             provider-id: equinixmetal://{{ `{{ v1.instance_id }}` }}
       preKubeadmCommands:
-      - |
+      - |-
         sed -ri '/\sswap\s/s/^#?/#/' /etc/fstab
         swapoff -a
         mount -a
@@ -46,14 +46,27 @@ spec:
         net.bridge.bridge-nf-call-ip6tables = 1
         EOF
         sysctl --system
-        apt-get -y update
-        DEBIAN_FRONTEND=noninteractive apt-get install -y apt-transport-https ca-certificates curl gnupg lsb-release linux-generic jq
-        curl -s https://packages.cloud.google.com/apt/doc/apt-key.gpg | apt-key add -
-        echo "deb https://apt.kubernetes.io/ kubernetes-xenial main" > /etc/apt/sources.list.d/kubernetes.list
+        export DEBIAN_FRONTEND=noninteractive
+        apt-get update -y
+        apt-get remove -y docker docker-engine docker.io containerd runc
+        apt-get install -y apt-transport-https ca-certificates curl gnupg lsb-release linux-generic jq
+        mkdir -p /etc/apt/keyrings
+        curl -fsSL https://download.docker.com/linux/ubuntu/gpg | gpg --dearmor -o /etc/apt/keyrings/docker.gpg
+        curl -fsSLo /usr/share/keyrings/kubernetes-archive-keyring.gpg https://packages.cloud.google.com/apt/doc/apt-key.gpg
+        echo "deb [arch=$(dpkg --print-architecture) signed-by=/etc/apt/keyrings/docker.gpg] https://download.docker.com/linux/ubuntu $(lsb_release -cs) stable" > /etc/apt/sources.list.d/docker.list
+        echo "deb [signed-by=/usr/share/keyrings/kubernetes-archive-keyring.gpg] https://apt.kubernetes.io/ kubernetes-xenial main" > /etc/apt/sources.list.d/kubernetes.list
         apt-get update -y
         TRIMMED_KUBERNETES_VERSION=$(echo {{ .kubernetesVersion }} | sed 's/\./\\\\./g' | sed 's/^v//')
-        RESOLVED_KUBERNETES_VERSION=$(apt-cache policy kubelet | awk -v VERSION=$${TRIMMED_KUBERNETES_VERSION} '$1~ VERSION { print $1 }' | head -n1)
-        DEBIAN_FRONTEND=noninteractive apt-get install -y containerd kubelet=$${RESOLVED_KUBERNETES_VERSION} kubeadm=$${RESOLVED_KUBERNETES_VERSION} kubectl=$${RESOLVED_KUBERNETES_VERSION}
+        RESOLVED_KUBERNETES_VERSION=$(apt-cache madison kubelet | awk -v VERSION=$${TRIMMED_KUBERNETES_VERSION} '$3~ VERSION { print $3 }' | head -n1)
+        apt-get install -y containerd kubelet=$${RESOLVED_KUBERNETES_VERSION} kubeadm=$${RESOLVED_KUBERNETES_VERSION} kubectl=$${RESOLVED_KUBERNETES_VERSION}
+        cat  <<EOF > /etc/crictl.yaml
+        runtime-endpoint: unix:///run/containerd/containerd.sock
+        image-endpoint: unix:///run/containerd/containerd.sock
+        EOF
+        containerd config default > /etc/containerd/config.toml
+        sed -i 's/SystemdCgroup = false/SystemdCgroup = true/' /etc/containerd/config.toml
+        sed -i "s,sandbox_image.*$,sandbox_image = $(kubeadm config images list | grep pause | sort -r | head -n1)," /etc/containerd/config.toml
+        systemctl restart containerd
 ---
 apiVersion: cluster.x-k8s.io/v1beta1
 kind: Cluster
@@ -146,6 +159,11 @@ spec:
       systemctl restart networking
       if [ -f "/run/kubeadm/kubeadm.yaml" ]; then
         export KUBECONFIG=/etc/kubernetes/admin.conf
+        mkdir -p /root/.kube && cp -f $${KUBECONFIG} /root/.kube/config
+        echo "export KUBECONFIG=/etc/kubernetes/admin.conf" >> /root/.bashrc
+        echo "source <(kubectl completion bash)" >> /root/.bashrc
+        echo "alias k=kubectl" >> /root/.bashrc
+        echo "complete -o default -F __start_kubectl k" >> /root/.bashrc
         export CPEM_YAML=https://github.com/equinix/cloud-provider-equinix-metal/releases/download/v3.5.0/deployment.yaml
         export SECRET_DATA='cloud-sa.json=''{"apiKey": "{{ .apiKey }}","projectID": "${PROJECT_ID}", "eipTag": "cluster-api-provider-packet:cluster-id:${CLUSTER_NAME}", "eipHealthCheckUseHostIP": true}'''
         kubectl create secret generic -n kube-system metal-cloud-config --from-literal="$${SECRET_DATA}" || (sleep 1 && kubectl create secret generic -n kube-system metal-cloud-config --from-literal="$${SECRET_DATA}") || (sleep 1 && kubectl create secret generic -n kube-system metal-cloud-config --from-literal="$${SECRET_DATA}")
@@ -168,14 +186,31 @@ spec:
       net.bridge.bridge-nf-call-ip6tables = 1
       EOF
       sysctl --system
-      apt-get -y update
-      DEBIAN_FRONTEND=noninteractive apt-get install -y apt-transport-https ca-certificates curl gnupg lsb-release linux-generic jq
-      curl -s https://packages.cloud.google.com/apt/doc/apt-key.gpg | apt-key add -
-      echo "deb https://apt.kubernetes.io/ kubernetes-xenial main" > /etc/apt/sources.list.d/kubernetes.list
+      export DEBIAN_FRONTEND=noninteractive
+      apt-get update -y
+      apt-get remove -y docker docker-engine docker.io containerd runc
+      apt-get install -y apt-transport-https ca-certificates curl gnupg lsb-release linux-generic jq
+      major_vers=$(lsb_release -r | awk '{ print $2 }' | cut -d. -f1)
+      if [[ "$major_vers" -ge 20 ]]; then
+        apt-get install -y kubetail
+      fi
+      mkdir -p /etc/apt/keyrings
+      curl -fsSL https://download.docker.com/linux/ubuntu/gpg | gpg --dearmor -o /etc/apt/keyrings/docker.gpg
+      curl -fsSLo /usr/share/keyrings/kubernetes-archive-keyring.gpg https://packages.cloud.google.com/apt/doc/apt-key.gpg
+      echo "deb [arch=$(dpkg --print-architecture) signed-by=/etc/apt/keyrings/docker.gpg] https://download.docker.com/linux/ubuntu $(lsb_release -cs) stable" > /etc/apt/sources.list.d/docker.list
+      echo "deb [signed-by=/usr/share/keyrings/kubernetes-archive-keyring.gpg] https://apt.kubernetes.io/ kubernetes-xenial main" > /etc/apt/sources.list.d/kubernetes.list
       apt-get update -y
       TRIMMED_KUBERNETES_VERSION=$(echo {{ .kubernetesVersion }} | sed 's/\./\\\\./g' | sed 's/^v//')
       RESOLVED_KUBERNETES_VERSION=$(apt-cache madison kubelet | awk -v VERSION=$${TRIMMED_KUBERNETES_VERSION} '$3~ VERSION { print $3 }' | head -n1)
-      DEBIAN_FRONTEND=noninteractive apt-get install -y containerd kubelet=$${RESOLVED_KUBERNETES_VERSION} kubeadm=$${RESOLVED_KUBERNETES_VERSION} kubectl=$${RESOLVED_KUBERNETES_VERSION}
+      apt-get install -y containerd kubelet=$${RESOLVED_KUBERNETES_VERSION} kubeadm=$${RESOLVED_KUBERNETES_VERSION} kubectl=$${RESOLVED_KUBERNETES_VERSION}
+      containerd config default > /etc/containerd/config.toml
+      cat  <<EOF > /etc/crictl.yaml
+      runtime-endpoint: unix:///run/containerd/containerd.sock
+      image-endpoint: unix:///run/containerd/containerd.sock
+      EOF
+      sed -i 's/SystemdCgroup = false/SystemdCgroup = true/' /etc/containerd/config.toml
+      sed -i "s,sandbox_image.*$,sandbox_image = $(kubeadm config images list | grep pause | sort -r | head -n1)," /etc/containerd/config.toml
+      systemctl restart containerd
       ping -c 3 -q {{ .controlPlaneEndpoint }} && echo OK || ip addr add {{ .controlPlaneEndpoint }} dev lo
   machineTemplate:
     infrastructureRef:

--- a/templates/cluster-template-kube-vip-crs-cni.yaml
+++ b/templates/cluster-template-kube-vip-crs-cni.yaml
@@ -153,7 +153,6 @@ spec:
       if [ -f "/run/kubeadm/kubeadm.yaml" ]; then
         export KUBECONFIG=/etc/kubernetes/admin.conf
         mkdir -p /root/.kube && cp -f $${KUBECONFIG} /root/.kube/config
-        echo "export KUBECONFIG=/etc/kubernetes/admin.conf" >> /root/.bashrc
         echo "source <(kubectl completion bash)" >> /root/.bashrc
         echo "alias k=kubectl" >> /root/.bashrc
         echo "complete -o default -F __start_kubectl k" >> /root/.bashrc

--- a/templates/cluster-template-kube-vip-crs-cni.yaml
+++ b/templates/cluster-template-kube-vip-crs-cni.yaml
@@ -46,14 +46,27 @@ spec:
         net.bridge.bridge-nf-call-ip6tables = 1
         EOF
         sysctl --system
-        apt-get -y update
-        DEBIAN_FRONTEND=noninteractive apt-get install -y apt-transport-https ca-certificates curl gnupg lsb-release linux-generic jq
-        curl -s https://packages.cloud.google.com/apt/doc/apt-key.gpg | apt-key add -
-        echo "deb https://apt.kubernetes.io/ kubernetes-xenial main" > /etc/apt/sources.list.d/kubernetes.list
+        export DEBIAN_FRONTEND=noninteractive
+        apt-get update -y
+        apt-get remove -y docker docker-engine docker.io containerd runc
+        apt-get install -y apt-transport-https ca-certificates curl gnupg lsb-release linux-generic jq
+        mkdir -p /etc/apt/keyrings
+        curl -fsSL https://download.docker.com/linux/ubuntu/gpg | gpg --dearmor -o /etc/apt/keyrings/docker.gpg
+        curl -fsSLo /usr/share/keyrings/kubernetes-archive-keyring.gpg https://packages.cloud.google.com/apt/doc/apt-key.gpg
+        echo "deb [arch=$(dpkg --print-architecture) signed-by=/etc/apt/keyrings/docker.gpg] https://download.docker.com/linux/ubuntu $(lsb_release -cs) stable" > /etc/apt/sources.list.d/docker.list
+        echo "deb [signed-by=/usr/share/keyrings/kubernetes-archive-keyring.gpg] https://apt.kubernetes.io/ kubernetes-xenial main" > /etc/apt/sources.list.d/kubernetes.list
         apt-get update -y
         TRIMMED_KUBERNETES_VERSION=$(echo {{ .kubernetesVersion }} | sed 's/\./\\\\./g' | sed 's/^v//')
         RESOLVED_KUBERNETES_VERSION=$(apt-cache madison kubelet | awk -v VERSION=$${TRIMMED_KUBERNETES_VERSION} '$3~ VERSION { print $3 }' | head -n1)
-        DEBIAN_FRONTEND=noninteractive apt-get install -y containerd kubelet=$${RESOLVED_KUBERNETES_VERSION} kubeadm=$${RESOLVED_KUBERNETES_VERSION} kubectl=$${RESOLVED_KUBERNETES_VERSION}
+        apt-get install -y containerd kubelet=$${RESOLVED_KUBERNETES_VERSION} kubeadm=$${RESOLVED_KUBERNETES_VERSION} kubectl=$${RESOLVED_KUBERNETES_VERSION}
+        cat  <<EOF > /etc/crictl.yaml
+        runtime-endpoint: unix:///run/containerd/containerd.sock
+        image-endpoint: unix:///run/containerd/containerd.sock
+        EOF
+        containerd config default > /etc/containerd/config.toml
+        sed -i 's/SystemdCgroup = false/SystemdCgroup = true/' /etc/containerd/config.toml
+        sed -i "s,sandbox_image.*$,sandbox_image = $(kubeadm config images list | grep pause | sort -r | head -n1)," /etc/containerd/config.toml
+        systemctl restart containerd
 ---
 apiVersion: cluster.x-k8s.io/v1beta1
 kind: Cluster
@@ -139,6 +152,11 @@ spec:
     - |-
       if [ -f "/run/kubeadm/kubeadm.yaml" ]; then
         export KUBECONFIG=/etc/kubernetes/admin.conf
+        mkdir -p /root/.kube && cp -f $${KUBECONFIG} /root/.kube/config
+        echo "export KUBECONFIG=/etc/kubernetes/admin.conf" >> /root/.bashrc
+        echo "source <(kubectl completion bash)" >> /root/.bashrc
+        echo "alias k=kubectl" >> /root/.bashrc
+        echo "complete -o default -F __start_kubectl k" >> /root/.bashrc
         export CPEM_YAML=https://github.com/equinix/cloud-provider-equinix-metal/releases/download/v3.5.0/deployment.yaml
         export SECRET_DATA='cloud-sa.json=''{"apiKey": "{{ .apiKey }}","projectID": "${PROJECT_ID}", "loadbalancer": "kube-vip://", "facility": "${FACILITY}"}'''
         kubectl create secret generic -n kube-system metal-cloud-config --from-literal="$${SECRET_DATA}" || (sleep 1 && kubectl create secret generic -n kube-system metal-cloud-config --from-literal="$${SECRET_DATA}") || (sleep 1 && kubectl create secret generic -n kube-system metal-cloud-config --from-literal="$${SECRET_DATA}")
@@ -161,14 +179,28 @@ spec:
       net.bridge.bridge-nf-call-ip6tables = 1
       EOF
       sysctl --system
-      apt-get -y update
-      DEBIAN_FRONTEND=noninteractive apt-get install -y apt-transport-https ca-certificates curl gnupg lsb-release linux-generic jq
-      curl -s https://packages.cloud.google.com/apt/doc/apt-key.gpg | apt-key add -
-      echo "deb https://apt.kubernetes.io/ kubernetes-xenial main" > /etc/apt/sources.list.d/kubernetes.list
+      export DEBIAN_FRONTEND=noninteractive
+      apt-get update -y
+      apt-get remove -y docker docker-engine docker.io containerd runc
+      apt-get install -y apt-transport-https ca-certificates curl gnupg lsb-release linux-generic jq
+      mkdir -p /etc/apt/keyrings
+      curl -fsSL https://download.docker.com/linux/ubuntu/gpg | gpg --dearmor -o /etc/apt/keyrings/docker.gpg
+      curl -fsSLo /usr/share/keyrings/kubernetes-archive-keyring.gpg https://packages.cloud.google.com/apt/doc/apt-key.gpg
+      echo "deb [arch=$(dpkg --print-architecture) signed-by=/etc/apt/keyrings/docker.gpg] https://download.docker.com/linux/ubuntu $(lsb_release -cs) stable" > /etc/apt/sources.list.d/docker.list
+      echo "deb [signed-by=/usr/share/keyrings/kubernetes-archive-keyring.gpg] https://apt.kubernetes.io/ kubernetes-xenial main" > /etc/apt/sources.list.d/kubernetes.list
       apt-get update -y
       TRIMMED_KUBERNETES_VERSION=$(echo {{ .kubernetesVersion }} | sed 's/\./\\\\./g' | sed 's/^v//')
       RESOLVED_KUBERNETES_VERSION=$(apt-cache madison kubelet | awk -v VERSION=$${TRIMMED_KUBERNETES_VERSION} '$3~ VERSION { print $3 }' | head -n1)
-      DEBIAN_FRONTEND=noninteractive apt-get install -y containerd kubelet=$${RESOLVED_KUBERNETES_VERSION} kubeadm=$${RESOLVED_KUBERNETES_VERSION} kubectl=$${RESOLVED_KUBERNETES_VERSION}
+      apt-get install -y containerd kubelet=$${RESOLVED_KUBERNETES_VERSION} kubeadm=$${RESOLVED_KUBERNETES_VERSION} kubectl=$${RESOLVED_KUBERNETES_VERSION}
+      cat  <<EOF > /etc/crictl.yaml
+      runtime-endpoint: unix:///run/containerd/containerd.sock
+      image-endpoint: unix:///run/containerd/containerd.sock
+      EOF
+      containerd config default > /etc/containerd/config.toml
+      sed -i 's/SystemdCgroup = false/SystemdCgroup = true/' /etc/containerd/config.toml
+      sed -i "s,sandbox_image.*$,sandbox_image = $(kubeadm config images list | grep pause | sort -r | head -n1)," /etc/containerd/config.toml
+      systemctl restart containerd
+      ping -c 3 -q {{ .controlPlaneEndpoint }} && echo OK || ip addr add {{ .controlPlaneEndpoint }} dev lo
       curl -o /run/metadata.json -fsSL https://metadata.platformequinix.com/metadata
       for i in $(cat /run/metadata.json | jq -r '.bgp_neighbors[0].peer_ips[]'); do
         ip route add $i via $(cat /run/metadata.json | jq -r '.network.addresses[] | select(.public == false and .address_family == 4) | .gateway')

--- a/templates/cluster-template-kube-vip.yaml
+++ b/templates/cluster-template-kube-vip.yaml
@@ -27,14 +27,27 @@ spec:
         net.bridge.bridge-nf-call-ip6tables = 1
         EOF
         sysctl --system
-        apt-get -y update
-        DEBIAN_FRONTEND=noninteractive apt-get install -y apt-transport-https ca-certificates curl gnupg lsb-release linux-generic jq
-        curl -s https://packages.cloud.google.com/apt/doc/apt-key.gpg | apt-key add -
-        echo "deb https://apt.kubernetes.io/ kubernetes-xenial main" > /etc/apt/sources.list.d/kubernetes.list
+        export DEBIAN_FRONTEND=noninteractive
+        apt-get update -y
+        apt-get remove -y docker docker-engine docker.io containerd runc
+        apt-get install -y apt-transport-https ca-certificates curl gnupg lsb-release linux-generic jq
+        mkdir -p /etc/apt/keyrings
+        curl -fsSL https://download.docker.com/linux/ubuntu/gpg | gpg --dearmor -o /etc/apt/keyrings/docker.gpg
+        curl -fsSLo /usr/share/keyrings/kubernetes-archive-keyring.gpg https://packages.cloud.google.com/apt/doc/apt-key.gpg
+        echo "deb [arch=$(dpkg --print-architecture) signed-by=/etc/apt/keyrings/docker.gpg] https://download.docker.com/linux/ubuntu $(lsb_release -cs) stable" > /etc/apt/sources.list.d/docker.list
+        echo "deb [signed-by=/usr/share/keyrings/kubernetes-archive-keyring.gpg] https://apt.kubernetes.io/ kubernetes-xenial main" > /etc/apt/sources.list.d/kubernetes.list
         apt-get update -y
         TRIMMED_KUBERNETES_VERSION=$(echo {{ .kubernetesVersion }} | sed 's/\./\\\\./g' | sed 's/^v//')
         RESOLVED_KUBERNETES_VERSION=$(apt-cache madison kubelet | awk -v VERSION=$${TRIMMED_KUBERNETES_VERSION} '$3~ VERSION { print $3 }' | head -n1)
-        DEBIAN_FRONTEND=noninteractive apt-get install -y containerd kubelet=$${RESOLVED_KUBERNETES_VERSION} kubeadm=$${RESOLVED_KUBERNETES_VERSION} kubectl=$${RESOLVED_KUBERNETES_VERSION}
+        apt-get install -y containerd kubelet=$${RESOLVED_KUBERNETES_VERSION} kubeadm=$${RESOLVED_KUBERNETES_VERSION} kubectl=$${RESOLVED_KUBERNETES_VERSION}
+        cat  <<EOF > /etc/crictl.yaml
+        runtime-endpoint: unix:///run/containerd/containerd.sock
+        image-endpoint: unix:///run/containerd/containerd.sock
+        EOF
+        containerd config default > /etc/containerd/config.toml
+        sed -i 's/SystemdCgroup = false/SystemdCgroup = true/' /etc/containerd/config.toml
+        sed -i "s,sandbox_image.*$,sandbox_image = $(kubeadm config images list | grep pause | sort -r | head -n1)," /etc/containerd/config.toml
+        systemctl restart containerd
 ---
 apiVersion: cluster.x-k8s.io/v1beta1
 kind: Cluster
@@ -118,6 +131,11 @@ spec:
     - |-
       if [ -f "/run/kubeadm/kubeadm.yaml" ]; then
         export KUBECONFIG=/etc/kubernetes/admin.conf
+        mkdir -p /root/.kube && cp -f $${KUBECONFIG} /root/.kube/config
+        echo "export KUBECONFIG=/etc/kubernetes/admin.conf" >> /root/.bashrc
+        echo "source <(kubectl completion bash)" >> /root/.bashrc
+        echo "alias k=kubectl" >> /root/.bashrc
+        echo "complete -o default -F __start_kubectl k" >> /root/.bashrc
         export CPEM_YAML=https://github.com/equinix/cloud-provider-equinix-metal/releases/download/v3.5.0/deployment.yaml
         export SECRET_DATA='cloud-sa.json=''{"apiKey": "{{ .apiKey }}","projectID": "${PROJECT_ID}", "loadbalancer": "kube-vip://", "facility": "${FACILITY}"}'''
         kubectl create secret generic -n kube-system metal-cloud-config --from-literal="$${SECRET_DATA}" || (sleep 1 && kubectl create secret generic -n kube-system metal-cloud-config --from-literal="$${SECRET_DATA}") || (sleep 1 && kubectl create secret generic -n kube-system metal-cloud-config --from-literal="$${SECRET_DATA}")
@@ -140,14 +158,28 @@ spec:
       net.bridge.bridge-nf-call-ip6tables = 1
       EOF
       sysctl --system
-      apt-get -y update
-      DEBIAN_FRONTEND=noninteractive apt-get install -y apt-transport-https ca-certificates curl gnupg lsb-release linux-generic jq
-      curl -s https://packages.cloud.google.com/apt/doc/apt-key.gpg | apt-key add -
-      echo "deb https://apt.kubernetes.io/ kubernetes-xenial main" > /etc/apt/sources.list.d/kubernetes.list
+      export DEBIAN_FRONTEND=noninteractive
+      apt-get update -y
+      apt-get remove -y docker docker-engine docker.io containerd runc
+      apt-get install -y apt-transport-https ca-certificates curl gnupg lsb-release linux-generic jq
+      mkdir -p /etc/apt/keyrings
+      curl -fsSL https://download.docker.com/linux/ubuntu/gpg | gpg --dearmor -o /etc/apt/keyrings/docker.gpg
+      curl -fsSLo /usr/share/keyrings/kubernetes-archive-keyring.gpg https://packages.cloud.google.com/apt/doc/apt-key.gpg
+      echo "deb [arch=$(dpkg --print-architecture) signed-by=/etc/apt/keyrings/docker.gpg] https://download.docker.com/linux/ubuntu $(lsb_release -cs) stable" > /etc/apt/sources.list.d/docker.list
+      echo "deb [signed-by=/usr/share/keyrings/kubernetes-archive-keyring.gpg] https://apt.kubernetes.io/ kubernetes-xenial main" > /etc/apt/sources.list.d/kubernetes.list
       apt-get update -y
       TRIMMED_KUBERNETES_VERSION=$(echo {{ .kubernetesVersion }} | sed 's/\./\\\\./g' | sed 's/^v//')
       RESOLVED_KUBERNETES_VERSION=$(apt-cache madison kubelet | awk -v VERSION=$${TRIMMED_KUBERNETES_VERSION} '$3~ VERSION { print $3 }' | head -n1)
-      DEBIAN_FRONTEND=noninteractive apt-get install -y containerd kubelet=$${RESOLVED_KUBERNETES_VERSION} kubeadm=$${RESOLVED_KUBERNETES_VERSION} kubectl=$${RESOLVED_KUBERNETES_VERSION}
+      apt-get install -y containerd kubelet=$${RESOLVED_KUBERNETES_VERSION} kubeadm=$${RESOLVED_KUBERNETES_VERSION} kubectl=$${RESOLVED_KUBERNETES_VERSION}
+      cat  <<EOF > /etc/crictl.yaml
+      runtime-endpoint: unix:///run/containerd/containerd.sock
+      image-endpoint: unix:///run/containerd/containerd.sock
+      EOF
+      containerd config default > /etc/containerd/config.toml
+      sed -i 's/SystemdCgroup = false/SystemdCgroup = true/' /etc/containerd/config.toml
+      sed -i "s,sandbox_image.*$,sandbox_image = $(kubeadm config images list | grep pause | sort -r | head -n1)," /etc/containerd/config.toml
+      systemctl restart containerd
+      ping -c 3 -q {{ .controlPlaneEndpoint }} && echo OK || ip addr add {{ .controlPlaneEndpoint }} dev lo
       curl -o /run/metadata.json -fsSL https://metadata.platformequinix.com/metadata
       for i in $(cat /run/metadata.json | jq -r '.bgp_neighbors[0].peer_ips[]'); do
         ip route add $i via $(cat /run/metadata.json | jq -r '.network.addresses[] | select(.public == false and .address_family == 4) | .gateway')

--- a/templates/cluster-template-kube-vip.yaml
+++ b/templates/cluster-template-kube-vip.yaml
@@ -132,7 +132,6 @@ spec:
       if [ -f "/run/kubeadm/kubeadm.yaml" ]; then
         export KUBECONFIG=/etc/kubernetes/admin.conf
         mkdir -p /root/.kube && cp -f $${KUBECONFIG} /root/.kube/config
-        echo "export KUBECONFIG=/etc/kubernetes/admin.conf" >> /root/.bashrc
         echo "source <(kubectl completion bash)" >> /root/.bashrc
         echo "alias k=kubectl" >> /root/.bashrc
         echo "complete -o default -F __start_kubectl k" >> /root/.bashrc

--- a/templates/cluster-template.yaml
+++ b/templates/cluster-template.yaml
@@ -47,14 +47,31 @@ spec:
         net.bridge.bridge-nf-call-ip6tables = 1
         EOF
         sysctl --system
-        apt-get -y update
-        DEBIAN_FRONTEND=noninteractive apt-get install -y apt-transport-https ca-certificates curl gnupg lsb-release linux-generic jq
-        curl -s https://packages.cloud.google.com/apt/doc/apt-key.gpg | apt-key add -
-        echo "deb https://apt.kubernetes.io/ kubernetes-xenial main" > /etc/apt/sources.list.d/kubernetes.list
+        export DEBIAN_FRONTEND=noninteractive
+        apt-get update -y
+        apt-get remove -y docker docker-engine docker.io containerd runc
+        apt-get install -y apt-transport-https ca-certificates curl gnupg lsb-release linux-generic jq
+        major_vers=$(lsb_release -r | awk '{ print $2 }' | cut -d. -f1)
+        if [[ "$major_vers" -ge 20 ]]; then
+          apt-get install -y kubetail
+        fi
+        mkdir -p /etc/apt/keyrings
+        curl -fsSL https://download.docker.com/linux/ubuntu/gpg | gpg --dearmor -o /etc/apt/keyrings/docker.gpg
+        curl -fsSLo /usr/share/keyrings/kubernetes-archive-keyring.gpg https://packages.cloud.google.com/apt/doc/apt-key.gpg
+        echo "deb [arch=$(dpkg --print-architecture) signed-by=/etc/apt/keyrings/docker.gpg] https://download.docker.com/linux/ubuntu $(lsb_release -cs) stable" > /etc/apt/sources.list.d/docker.list
+        echo "deb [signed-by=/usr/share/keyrings/kubernetes-archive-keyring.gpg] https://apt.kubernetes.io/ kubernetes-xenial main" > /etc/apt/sources.list.d/kubernetes.list
         apt-get update -y
         TRIMMED_KUBERNETES_VERSION=$(echo {{ .kubernetesVersion }} | sed 's/\./\\\\./g' | sed 's/^v//')
         RESOLVED_KUBERNETES_VERSION=$(apt-cache madison kubelet | awk -v VERSION=$${TRIMMED_KUBERNETES_VERSION} '$3~ VERSION { print $3 }' | head -n1)
-        DEBIAN_FRONTEND=noninteractive apt-get install -y containerd kubelet=$${RESOLVED_KUBERNETES_VERSION} kubeadm=$${RESOLVED_KUBERNETES_VERSION} kubectl=$${RESOLVED_KUBERNETES_VERSION}
+        apt-get install -y containerd kubelet=$${RESOLVED_KUBERNETES_VERSION} kubeadm=$${RESOLVED_KUBERNETES_VERSION} kubectl=$${RESOLVED_KUBERNETES_VERSION}
+        containerd config default > /etc/containerd/config.toml
+        cat  <<EOF > /etc/crictl.yaml
+        runtime-endpoint: unix:///run/containerd/containerd.sock
+        image-endpoint: unix:///run/containerd/containerd.sock
+        EOF
+        sed -i 's/SystemdCgroup = false/SystemdCgroup = true/' /etc/containerd/config.toml
+        sed -i "s,sandbox_image.*$,sandbox_image = $(kubeadm config images list | grep pause | sort -r | head -n1)," /etc/containerd/config.toml
+        systemctl restart containerd
         ping -c 3 -q {{ .controlPlaneEndpoint }} && echo OK || ip addr add {{ .controlPlaneEndpoint }} dev lo
     postKubeadmCommands:
       - |
@@ -67,6 +84,11 @@ spec:
         systemctl restart networking
         if [ -f "/run/kubeadm/kubeadm.yaml" ]; then
           export KUBECONFIG=/etc/kubernetes/admin.conf
+          mkdir -p /root/.kube && cp -f $${KUBECONFIG} /root/.kube/config
+          echo "export KUBECONFIG=/etc/kubernetes/admin.conf" >> /root/.bashrc
+          echo "source <(kubectl completion bash)" >> /root/.bashrc
+          echo "alias k=kubectl" >> /root/.bashrc
+          echo "complete -o default -F __start_kubectl k" >> /root/.bashrc
           export CPEM_YAML=https://github.com/equinix/cloud-provider-equinix-metal/releases/download/v3.5.0/deployment.yaml
           export SECRET_DATA='cloud-sa.json=''{"apiKey": "{{ .apiKey }}","projectID": "${PROJECT_ID}", "eipTag": "cluster-api-provider-packet:cluster-id:${CLUSTER_NAME}", "eipHealthCheckUseHostIP": true}'''
           kubectl create secret generic -n kube-system metal-cloud-config --from-literal="$${SECRET_DATA}" || (sleep 1 && kubectl create secret generic -n kube-system metal-cloud-config --from-literal="$${SECRET_DATA}") || (sleep 1 && kubectl create secret generic -n kube-system metal-cloud-config --from-literal="$${SECRET_DATA}")
@@ -192,11 +214,24 @@ spec:
           net.bridge.bridge-nf-call-ip6tables = 1
           EOF
           sysctl --system
-          apt-get -y update
-          DEBIAN_FRONTEND=noninteractive apt-get install -y apt-transport-https ca-certificates curl gnupg lsb-release linux-generic jq
-          curl -s https://packages.cloud.google.com/apt/doc/apt-key.gpg | apt-key add -
-          echo "deb https://apt.kubernetes.io/ kubernetes-xenial main" > /etc/apt/sources.list.d/kubernetes.list
+          export DEBIAN_FRONTEND=noninteractive
+          apt-get update -y
+          apt-get remove -y docker docker-engine docker.io containerd runc
+          apt-get install -y apt-transport-https ca-certificates curl gnupg lsb-release linux-generic jq
+          mkdir -p /etc/apt/keyrings
+          curl -fsSL https://download.docker.com/linux/ubuntu/gpg | gpg --dearmor -o /etc/apt/keyrings/docker.gpg
+          curl -fsSLo /usr/share/keyrings/kubernetes-archive-keyring.gpg https://packages.cloud.google.com/apt/doc/apt-key.gpg
+          echo "deb [arch=$(dpkg --print-architecture) signed-by=/etc/apt/keyrings/docker.gpg] https://download.docker.com/linux/ubuntu $(lsb_release -cs) stable" > /etc/apt/sources.list.d/docker.list
+          echo "deb [signed-by=/usr/share/keyrings/kubernetes-archive-keyring.gpg] https://apt.kubernetes.io/ kubernetes-xenial main" > /etc/apt/sources.list.d/kubernetes.list
           apt-get update -y
           TRIMMED_KUBERNETES_VERSION=$(echo {{ .kubernetesVersion }} | sed 's/\./\\\\./g' | sed 's/^v//')
-          RESOLVED_KUBERNETES_VERSION=$(apt-cache policy kubelet | awk -v VERSION=$${TRIMMED_KUBERNETES_VERSION} '$1~ VERSION { print $1 }' | head -n1)
-          DEBIAN_FRONTEND=noninteractive apt-get install -y containerd kubelet=$${RESOLVED_KUBERNETES_VERSION} kubeadm=$${RESOLVED_KUBERNETES_VERSION} kubectl=$${RESOLVED_KUBERNETES_VERSION}
+          RESOLVED_KUBERNETES_VERSION=$(apt-cache madison kubelet | awk -v VERSION=$${TRIMMED_KUBERNETES_VERSION} '$3~ VERSION { print $3 }' | head -n1)
+          apt-get install -y containerd kubelet=$${RESOLVED_KUBERNETES_VERSION} kubeadm=$${RESOLVED_KUBERNETES_VERSION} kubectl=$${RESOLVED_KUBERNETES_VERSION}
+          cat  <<EOF > /etc/crictl.yaml
+          runtime-endpoint: unix:///run/containerd/containerd.sock
+          image-endpoint: unix:///run/containerd/containerd.sock
+          EOF
+          containerd config default > /etc/containerd/config.toml
+          sed -i 's/SystemdCgroup = false/SystemdCgroup = true/' /etc/containerd/config.toml
+          sed -i "s,sandbox_image.*$,sandbox_image = $(kubeadm config images list | grep pause | sort -r | head -n1)," /etc/containerd/config.toml
+          systemctl restart containerd

--- a/templates/cluster-template.yaml
+++ b/templates/cluster-template.yaml
@@ -85,7 +85,6 @@ spec:
         if [ -f "/run/kubeadm/kubeadm.yaml" ]; then
           export KUBECONFIG=/etc/kubernetes/admin.conf
           mkdir -p /root/.kube && cp -f $${KUBECONFIG} /root/.kube/config
-          echo "export KUBECONFIG=/etc/kubernetes/admin.conf" >> /root/.bashrc
           echo "source <(kubectl completion bash)" >> /root/.bashrc
           echo "alias k=kubectl" >> /root/.bashrc
           echo "complete -o default -F __start_kubectl k" >> /root/.bashrc

--- a/templates/experimental-kube-vip/kustomization.yaml
+++ b/templates/experimental-kube-vip/kustomization.yaml
@@ -35,14 +35,28 @@ patches:
             net.bridge.bridge-nf-call-ip6tables = 1
             EOF
             sysctl --system
-            apt-get -y update
-            DEBIAN_FRONTEND=noninteractive apt-get install -y apt-transport-https ca-certificates curl gnupg lsb-release linux-generic jq
-            curl -s https://packages.cloud.google.com/apt/doc/apt-key.gpg | apt-key add -
-            echo "deb https://apt.kubernetes.io/ kubernetes-xenial main" > /etc/apt/sources.list.d/kubernetes.list
+            export DEBIAN_FRONTEND=noninteractive
+            apt-get update -y
+            apt-get remove -y docker docker-engine docker.io containerd runc
+            apt-get install -y apt-transport-https ca-certificates curl gnupg lsb-release linux-generic jq
+            mkdir -p /etc/apt/keyrings
+            curl -fsSL https://download.docker.com/linux/ubuntu/gpg | gpg --dearmor -o /etc/apt/keyrings/docker.gpg
+            curl -fsSLo /usr/share/keyrings/kubernetes-archive-keyring.gpg https://packages.cloud.google.com/apt/doc/apt-key.gpg
+            echo "deb [arch=$(dpkg --print-architecture) signed-by=/etc/apt/keyrings/docker.gpg] https://download.docker.com/linux/ubuntu $(lsb_release -cs) stable" > /etc/apt/sources.list.d/docker.list
+            echo "deb [signed-by=/usr/share/keyrings/kubernetes-archive-keyring.gpg] https://apt.kubernetes.io/ kubernetes-xenial main" > /etc/apt/sources.list.d/kubernetes.list
             apt-get update -y
             TRIMMED_KUBERNETES_VERSION=$(echo {{ .kubernetesVersion }} | sed 's/\./\\\\./g' | sed 's/^v//')
             RESOLVED_KUBERNETES_VERSION=$(apt-cache madison kubelet | awk -v VERSION=$${TRIMMED_KUBERNETES_VERSION} '$3~ VERSION { print $3 }' | head -n1)
-            DEBIAN_FRONTEND=noninteractive apt-get install -y containerd kubelet=$${RESOLVED_KUBERNETES_VERSION} kubeadm=$${RESOLVED_KUBERNETES_VERSION} kubectl=$${RESOLVED_KUBERNETES_VERSION}
+            apt-get install -y containerd kubelet=$${RESOLVED_KUBERNETES_VERSION} kubeadm=$${RESOLVED_KUBERNETES_VERSION} kubectl=$${RESOLVED_KUBERNETES_VERSION}
+            cat  <<EOF > /etc/crictl.yaml
+            runtime-endpoint: unix:///run/containerd/containerd.sock
+            image-endpoint: unix:///run/containerd/containerd.sock
+            EOF
+            containerd config default > /etc/containerd/config.toml
+            sed -i 's/SystemdCgroup = false/SystemdCgroup = true/' /etc/containerd/config.toml
+            sed -i "s,sandbox_image.*$,sandbox_image = $(kubeadm config images list | grep pause | sort -r | head -n1)," /etc/containerd/config.toml
+            systemctl restart containerd
+            ping -c 3 -q {{ .controlPlaneEndpoint }} && echo OK || ip addr add {{ .controlPlaneEndpoint }} dev lo
             curl -o /run/metadata.json -fsSL https://metadata.platformequinix.com/metadata
             for i in $(cat /run/metadata.json | jq -r '.bgp_neighbors[0].peer_ips[]'); do
               ip route add $i via $(cat /run/metadata.json | jq -r '.network.addresses[] | select(.public == false and .address_family == 4) | .gateway')
@@ -63,6 +77,11 @@ patches:
           - |
             if [ -f "/run/kubeadm/kubeadm.yaml" ]; then
               export KUBECONFIG=/etc/kubernetes/admin.conf
+              mkdir -p /root/.kube && cp -f $${KUBECONFIG} /root/.kube/config
+              echo "export KUBECONFIG=/etc/kubernetes/admin.conf" >> /root/.bashrc
+              echo "source <(kubectl completion bash)" >> /root/.bashrc
+              echo "alias k=kubectl" >> /root/.bashrc
+              echo "complete -o default -F __start_kubectl k" >> /root/.bashrc
               export CPEM_YAML=https://github.com/equinix/cloud-provider-equinix-metal/releases/download/v3.5.0/deployment.yaml
               export SECRET_DATA='cloud-sa.json=''{"apiKey": "{{ .apiKey }}","projectID": "${PROJECT_ID}", "loadbalancer": "kube-vip://", "facility": "${FACILITY}"}'''
               kubectl create secret generic -n kube-system metal-cloud-config --from-literal="$${SECRET_DATA}" || (sleep 1 && kubectl create secret generic -n kube-system metal-cloud-config --from-literal="$${SECRET_DATA}") || (sleep 1 && kubectl create secret generic -n kube-system metal-cloud-config --from-literal="$${SECRET_DATA}")
@@ -93,11 +112,24 @@ patches:
               net.bridge.bridge-nf-call-ip6tables = 1
               EOF
               sysctl --system
-              apt-get -y update
-              DEBIAN_FRONTEND=noninteractive apt-get install -y apt-transport-https ca-certificates curl gnupg lsb-release linux-generic jq
-              curl -s https://packages.cloud.google.com/apt/doc/apt-key.gpg | apt-key add -
-              echo "deb https://apt.kubernetes.io/ kubernetes-xenial main" > /etc/apt/sources.list.d/kubernetes.list
+              export DEBIAN_FRONTEND=noninteractive
+              apt-get update -y
+              apt-get remove -y docker docker-engine docker.io containerd runc
+              apt-get install -y apt-transport-https ca-certificates curl gnupg lsb-release linux-generic jq
+              mkdir -p /etc/apt/keyrings
+              curl -fsSL https://download.docker.com/linux/ubuntu/gpg | gpg --dearmor -o /etc/apt/keyrings/docker.gpg
+              curl -fsSLo /usr/share/keyrings/kubernetes-archive-keyring.gpg https://packages.cloud.google.com/apt/doc/apt-key.gpg
+              echo "deb [arch=$(dpkg --print-architecture) signed-by=/etc/apt/keyrings/docker.gpg] https://download.docker.com/linux/ubuntu $(lsb_release -cs) stable" > /etc/apt/sources.list.d/docker.list
+              echo "deb [signed-by=/usr/share/keyrings/kubernetes-archive-keyring.gpg] https://apt.kubernetes.io/ kubernetes-xenial main" > /etc/apt/sources.list.d/kubernetes.list
               apt-get update -y
               TRIMMED_KUBERNETES_VERSION=$(echo {{ .kubernetesVersion }} | sed 's/\./\\\\./g' | sed 's/^v//')
               RESOLVED_KUBERNETES_VERSION=$(apt-cache madison kubelet | awk -v VERSION=$${TRIMMED_KUBERNETES_VERSION} '$3~ VERSION { print $3 }' | head -n1)
-              DEBIAN_FRONTEND=noninteractive apt-get install -y containerd kubelet=$${RESOLVED_KUBERNETES_VERSION} kubeadm=$${RESOLVED_KUBERNETES_VERSION} kubectl=$${RESOLVED_KUBERNETES_VERSION}
+              apt-get install -y containerd kubelet=$${RESOLVED_KUBERNETES_VERSION} kubeadm=$${RESOLVED_KUBERNETES_VERSION} kubectl=$${RESOLVED_KUBERNETES_VERSION}
+              cat  <<EOF > /etc/crictl.yaml
+              runtime-endpoint: unix:///run/containerd/containerd.sock
+              image-endpoint: unix:///run/containerd/containerd.sock
+              EOF
+              containerd config default > /etc/containerd/config.toml
+              sed -i 's/SystemdCgroup = false/SystemdCgroup = true/' /etc/containerd/config.toml
+              sed -i "s,sandbox_image.*$,sandbox_image = $(kubeadm config images list | grep pause | sort -r | head -n1)," /etc/containerd/config.toml
+              systemctl restart containerd

--- a/templates/experimental-kube-vip/kustomization.yaml
+++ b/templates/experimental-kube-vip/kustomization.yaml
@@ -78,7 +78,6 @@ patches:
             if [ -f "/run/kubeadm/kubeadm.yaml" ]; then
               export KUBECONFIG=/etc/kubernetes/admin.conf
               mkdir -p /root/.kube && cp -f $${KUBECONFIG} /root/.kube/config
-              echo "export KUBECONFIG=/etc/kubernetes/admin.conf" >> /root/.bashrc
               echo "source <(kubectl completion bash)" >> /root/.bashrc
               echo "alias k=kubectl" >> /root/.bashrc
               echo "complete -o default -F __start_kubectl k" >> /root/.bashrc

--- a/test/e2e/config/packet-ci-actions.yaml
+++ b/test/e2e/config/packet-ci-actions.yaml
@@ -31,8 +31,8 @@ providers:
         new: --metrics-addr=:8080
     files:
     - sourcePath: "../data/shared/v1beta1/metadata.yaml"
-  - name: v1.1.3 # latest published release in the v1beta1 series
-    value: "https://github.com/kubernetes-sigs/cluster-api/releases/download/v1.1.3/core-components.yaml"
+  - name: v1.1.5 # latest published release in the v1beta1 series
+    value: "https://github.com/kubernetes-sigs/cluster-api/releases/download/v1.1.5/core-components.yaml"
     type: "url"
     contract: v1beta1
     replacements:
@@ -62,8 +62,8 @@ providers:
         new: --metrics-addr=:8080
     files:
     - sourcePath: "../data/shared/v1beta1/metadata.yaml"
-  - name: v1.1.3 # latest published release in the v1beta1 series
-    value: "https://github.com/kubernetes-sigs/cluster-api/releases/download/v1.1.3/bootstrap-components.yaml"
+  - name: v1.1.5 # latest published release in the v1beta1 series
+    value: "https://github.com/kubernetes-sigs/cluster-api/releases/download/v1.1.5/bootstrap-components.yaml"
     type: "url"
     contract: v1beta1
     replacements:
@@ -93,8 +93,8 @@ providers:
         new: --metrics-addr=:8080
     files:
     - sourcePath: "../data/shared/v1beta1/metadata.yaml"
-  - name: v1.1.3 # latest published release in the v1beta1 series; this is used for v1beta1 --> main clusterctl upgrades test only.
-    value: "https://github.com/kubernetes-sigs/cluster-api/releases/download/v1.1.3/control-plane-components.yaml"
+  - name: v1.1.5 # latest published release in the v1beta1 series; this is used for v1beta1 --> main clusterctl upgrades test only.
+    value: "https://github.com/kubernetes-sigs/cluster-api/releases/download/v1.1.5/control-plane-components.yaml"
     type: "url"
     contract: v1beta1
     replacements:
@@ -139,12 +139,12 @@ providers:
     - sourcePath: "../data/v1beta1/cluster-template-kcp-remediation.yaml"
 
 variables:
-  KUBERNETES_VERSION_MANAGEMENT: "v1.23.3"
-  KUBERNETES_VERSION: "${KUBERNETES_VERSION:-v1.23.3}"
-  KUBERNETES_VERSION_UPGRADE_FROM: "v1.22.4"
-  KUBERNETES_VERSION_UPGRADE_TO: "v1.23.3"
-  ETCD_VERSION_UPGRADE_TO: "3.5.1-0"
-  COREDNS_VERSION_UPGRADE_TO: "v1.8.4"
+  KUBERNETES_VERSION_MANAGEMENT: "v1.24.0"
+  KUBERNETES_VERSION: "${KUBERNETES_VERSION:-v1.24.0}"
+  KUBERNETES_VERSION_UPGRADE_FROM: "v1.23.6"
+  KUBERNETES_VERSION_UPGRADE_TO: "v1.24.0"
+  ETCD_VERSION_UPGRADE_TO: "3.5.3-0"
+  COREDNS_VERSION_UPGRADE_TO: "v1.8.6"
 
   # Infra provider specific variables
   NODE_OS: "ubuntu_18_04"


### PR DESCRIPTION
**What this PR does / why we need it**:
Update docker and k8s debian key registrations
Add crictl default container runtime configuration
Install kubetail on ubuntu 20+
export DEBIAN_FRONTEND=noninteractive once
Configure containerd to use Systemd cgroups
Configure containerd to use the pause image of installed k8s


**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #403
