### PR TITLE
Update go install script and add kustomize install script

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -79,6 +79,7 @@ GOLANGCI_LINT_BIN := golangci-lint
 GOLANGCI_LINT := $(TOOLS_BIN_DIR)/$(GOLANGCI_LINT_BIN)-$(GOLANGCI_LINT_VER)
 
 # Keep at 4.0.4 until we figure out how to get later verisons to not mangle the calico yamls
+# HACK bump latest version once https://github.com/kubernetes-sigs/kustomize/issues/947 is fixed
 KUSTOMIZE_VER := v4.0.4
 KUSTOMIZE_BIN := kustomize
 KUSTOMIZE := $(TOOLS_BIN_DIR)/$(KUSTOMIZE_BIN)-$(KUSTOMIZE_VER)
@@ -224,8 +225,13 @@ $(ENVSUBST): ## Build envsubst from tools folder.
 $(GOLANGCI_LINT): ## Build golangci-lint from tools folder.
 	GOBIN=$(TOOLS_BIN_DIR) $(GO_INSTALL) github.com/golangci/golangci-lint/cmd/golangci-lint $(GOLANGCI_LINT_BIN) $(GOLANGCI_LINT_VER)
 
-$(KUSTOMIZE): ## Build kustomize from tools folder.
-	GOBIN=$(TOOLS_BIN_DIR) $(GO_INSTALL) sigs.k8s.io/kustomize/kustomize/v4 $(KUSTOMIZE_BIN) $(KUSTOMIZE_VER)
+## HACK replace with $(GO_INSTALL) once https://github.com/kubernetes-sigs/kustomize/issues/947 is fixed
+$(KUSTOMIZE): ## Put kustomize into tools folder.
+	mkdir -p $(TOOLS_BIN_DIR)
+	rm -f $(TOOLS_BIN_DIR)/$(KUSTOMIZE_BIN)*
+	curl -fsSL "https://raw.githubusercontent.com/kubernetes-sigs/kustomize/master/hack/install_kustomize.sh" | bash -s -- $(KUSTOMIZE_VER:v%=%) $(TOOLS_BIN_DIR)
+	mv "$(TOOLS_BIN_DIR)/$(KUSTOMIZE_BIN)" $(KUSTOMIZE)
+	ln -sf $(KUSTOMIZE) "$(TOOLS_BIN_DIR)/$(KUSTOMIZE_BIN)"
 
 $(CONTROLLER_GEN): ## Build controller-gen from tools folder.
 	GOBIN=$(TOOLS_BIN_DIR) $(GO_INSTALL) sigs.k8s.io/controller-tools/cmd/controller-gen $(CONTROLLER_GEN_BIN) $(CONTROLLER_GEN_VER)

--- a/scripts/go_install.sh
+++ b/scripts/go_install.sh
@@ -37,20 +37,9 @@ if [ -z "${GOBIN}" ]; then
   exit 1
 fi
 
-tmp_dir=$(mktemp -d -t goinstall_XXXXXXXXXX)
-function clean {
-  rm -rf "${tmp_dir}"
-}
-trap clean EXIT
-
 rm "${GOBIN}/${2}"* || true
 
-cd "${tmp_dir}"
-
-# create a new module in the tmp directory
-go mod init fake/mod
-
 # install the golang module specified as the first argument
-go get -tags tools "${1}@${3}"
+go install -tags tools "${1}@${3}"
 mv "${GOBIN}/${2}" "${GOBIN}/${2}-${3}"
 ln -sf "${GOBIN}/${2}-${3}" "${GOBIN}/${2}"


### PR DESCRIPTION
**What this PR does / why we need it:**
Updates scripts/go_install.sh file to use `go install` instead of `go get` which was deprecated in golang 1.17 and it no longer install packages after 1.18. It is required to execute e2e tests locally with latest go version, and will be required before update the go version in [all github actions and other references](https://github.com/kubernetes-sigs/cluster-api-provider-packet/issues/410). Issue https://github.com/kubernetes-sigs/cluster-api-provider-packet/issues/410 contains more information about the kustomize installation changes included in this PR.

**Which issue(s) this PR fixes (optional, in fixes #<issue number>(, fixes #<issue_number>, ...) format, will close the issue(s) when PR gets merged):**
fixes https://github.com/kubernetes-sigs/cluster-api-provider-packet/issues/410
