### PR TITLE
Update templates

### DIFF
--- a/templates/cluster-template-crs-cni.yaml
+++ b/templates/cluster-template-crs-cni.yaml
@@ -157,11 +157,13 @@ spec:
         netmask 255.255.255.255
       EOF
       systemctl restart networking
-      mkdir -p /root/.kube && cp -f /etc/kubernetes/admin.conf /root/.kube/config
-      echo "source <(kubectl completion bash)" >> /root/.bashrc
-      echo "alias k=kubectl" >> /root/.bashrc
-      echo "complete -o default -F __start_kubectl k" >> /root/.bashrc
+      mkdir -p $HOME/.kube
+      cp /etc/kubernetes/admin.conf $HOME/.kube/config
+      echo "source <(kubectl completion bash)" >> $HOME/.bashrc
+      echo "alias k=kubectl" >> $HOME/.bashrc
+      echo "complete -o default -F __start_kubectl k" >> $HOME/.bashrc
       if [ -f "/run/kubeadm/kubeadm.yaml" ]; then
+        export KUBECONFIG=/etc/kubernetes/admin.conf
         export CPEM_YAML=https://github.com/equinix/cloud-provider-equinix-metal/releases/download/${CPEM_VERSION:=v3.5.0}/deployment.yaml
         export SECRET_DATA='cloud-sa.json=''{"apiKey": "{{ .apiKey }}","projectID": "${PROJECT_ID}", "eipTag": "cluster-api-provider-packet:cluster-id:${CLUSTER_NAME}", "eipHealthCheckUseHostIP": true}'''
         kubectl create secret generic -n kube-system metal-cloud-config --from-literal="$${SECRET_DATA}" || (sleep 1 && kubectl create secret generic -n kube-system metal-cloud-config --from-literal="$${SECRET_DATA}") || (sleep 1 && kubectl create secret generic -n kube-system metal-cloud-config --from-literal="$${SECRET_DATA}")

--- a/templates/cluster-template-kube-vip-crs-cni.yaml
+++ b/templates/cluster-template-kube-vip-crs-cni.yaml
@@ -150,11 +150,13 @@ spec:
           provider-id: equinixmetal://{{ `{{ v1.instance_id }}` }}
     postKubeadmCommands:
     - |-
-      curl -o /run/metadata.json -fsSL https://metadata.platformequinix.com/metadata
-      for i in $(cat /run/metadata.json | jq -r '.bgp_neighbors[0].peer_ips[]'); do
-        ip route add $i via $(cat /run/metadata.json | jq -r '.network.addresses[] | select(.public == false and .address_family == 4) | .gateway')
-      done
+      mkdir -p $HOME/.kube
+      cp /etc/kubernetes/admin.conf $HOME/.kube/config
+      echo "source <(kubectl completion bash)" >> $HOME/.bashrc
+      echo "alias k=kubectl" >> $HOME/.bashrc
+      echo "complete -o default -F __start_kubectl k" >> $HOME/.bashrc
       if [ -f "/run/kubeadm/kubeadm.yaml" ]; then
+        export KUBECONFIG=/etc/kubernetes/admin.conf
         export CPEM_YAML=https://github.com/equinix/cloud-provider-equinix-metal/releases/download/${CPEM_VERSION:=v3.5.0}/deployment.yaml
         export SECRET_DATA='cloud-sa.json=''{"apiKey": "{{ .apiKey }}","projectID": "${PROJECT_ID}", "loadbalancer": "kube-vip://", "facility": "${FACILITY}"}'''
         kubectl create secret generic -n kube-system metal-cloud-config --from-literal="$${SECRET_DATA}" || (sleep 1 && kubectl create secret generic -n kube-system metal-cloud-config --from-literal="$${SECRET_DATA}") || (sleep 1 && kubectl create secret generic -n kube-system metal-cloud-config --from-literal="$${SECRET_DATA}")
@@ -171,12 +173,8 @@ spec:
         --peerAddress $(cat /run/metadata.json | jq -r '.bgp_neighbors[0].peer_ips[0]') \
         --localAS $(cat /run/metadata.json | jq -r '.bgp_neighbors[0].customer_as') \
         --bgpRouterID $(cat /run/metadata.json | jq -r '.bgp_neighbors[0].customer_ip') > /etc/kubernetes/manifests/vip.yaml
-        rm /run/metadata.json
-        mkdir -p /root/.kube && cp -f /etc/kubernetes/admin.conf /root/.kube/config
-        echo "source <(kubectl completion bash)" >> /root/.bashrc
-        echo "alias k=kubectl" >> /root/.bashrc
-        echo "complete -o default -F __start_kubectl k" >> /root/.bashrc
       fi
+      rm /run/metadata.json
     preKubeadmCommands:
     - |
       sed -ri '/\sswap\s/s/^#?/#/' /etc/fstab
@@ -215,12 +213,12 @@ spec:
       sed -i 's/SystemdCgroup = false/SystemdCgroup = true/' /etc/containerd/config.toml
       sed -i "s,sandbox_image.*$,sandbox_image = \"$(kubeadm config images list | grep pause | sort -r | head -n1)\"," /etc/containerd/config.toml
       systemctl restart containerd
+      curl -o /run/metadata.json -fsSL https://metadata.platformequinix.com/metadata
+      for i in $(cat /run/metadata.json | jq -r '.bgp_neighbors[0].peer_ips[]'); do
+        ip route add $i via $(cat /run/metadata.json | jq -r '.network.addresses[] | select(.public == false and .address_family == 4) | .gateway')
+      done
       if [ -f "/run/kubeadm/kubeadm.yaml" ]; then
         ip addr add {{ .controlPlaneEndpoint }} dev lo
-        curl -o /run/metadata.json -fsSL https://metadata.platformequinix.com/metadata
-        for i in $(cat /run/metadata.json | jq -r '.bgp_neighbors[0].peer_ips[]'); do
-          ip route add $i via $(cat /run/metadata.json | jq -r '.network.addresses[] | select(.public == false and .address_family == 4) | .gateway')
-        done
         KVVERSION="${KUBE_VIP_VERSION:=v0.5.0}"
         ctr image pull ghcr.io/kube-vip/kube-vip:$${KVVERSION}
         ctr run --rm --net-host ghcr.io/kube-vip/kube-vip:$KVVERSION vip /kube-vip manifest pod \
@@ -232,7 +230,6 @@ spec:
         --peerAddress $(cat /run/metadata.json | jq -r '.bgp_neighbors[0].peer_ips[0]') \
         --localAS $(cat /run/metadata.json | jq -r '.bgp_neighbors[0].customer_as') \
         --bgpRouterID $(cat /run/metadata.json | jq -r '.bgp_neighbors[0].customer_ip') > /etc/kubernetes/manifests/vip.yaml
-        rm /run/metadata.json
       fi
   machineTemplate:
     infrastructureRef:

--- a/templates/cluster-template-kube-vip.yaml
+++ b/templates/cluster-template-kube-vip.yaml
@@ -129,11 +129,13 @@ spec:
           provider-id: equinixmetal://{{ `{{ v1.instance_id }}` }}
     postKubeadmCommands:
     - |-
-      curl -o /run/metadata.json -fsSL https://metadata.platformequinix.com/metadata
-      for i in $(cat /run/metadata.json | jq -r '.bgp_neighbors[0].peer_ips[]'); do
-        ip route add $i via $(cat /run/metadata.json | jq -r '.network.addresses[] | select(.public == false and .address_family == 4) | .gateway')
-      done
+      mkdir -p $HOME/.kube
+      cp /etc/kubernetes/admin.conf $HOME/.kube/config
+      echo "source <(kubectl completion bash)" >> $HOME/.bashrc
+      echo "alias k=kubectl" >> $HOME/.bashrc
+      echo "complete -o default -F __start_kubectl k" >> $HOME/.bashrc
       if [ -f "/run/kubeadm/kubeadm.yaml" ]; then
+        export KUBECONFIG=/etc/kubernetes/admin.conf
         export CPEM_YAML=https://github.com/equinix/cloud-provider-equinix-metal/releases/download/${CPEM_VERSION:=v3.5.0}/deployment.yaml
         export SECRET_DATA='cloud-sa.json=''{"apiKey": "{{ .apiKey }}","projectID": "${PROJECT_ID}", "loadbalancer": "kube-vip://", "facility": "${FACILITY}"}'''
         kubectl create secret generic -n kube-system metal-cloud-config --from-literal="$${SECRET_DATA}" || (sleep 1 && kubectl create secret generic -n kube-system metal-cloud-config --from-literal="$${SECRET_DATA}") || (sleep 1 && kubectl create secret generic -n kube-system metal-cloud-config --from-literal="$${SECRET_DATA}")
@@ -150,12 +152,8 @@ spec:
         --peerAddress $(cat /run/metadata.json | jq -r '.bgp_neighbors[0].peer_ips[0]') \
         --localAS $(cat /run/metadata.json | jq -r '.bgp_neighbors[0].customer_as') \
         --bgpRouterID $(cat /run/metadata.json | jq -r '.bgp_neighbors[0].customer_ip') > /etc/kubernetes/manifests/vip.yaml
-        rm /run/metadata.json
-        mkdir -p /root/.kube && cp -f /etc/kubernetes/admin.conf /root/.kube/config
-        echo "source <(kubectl completion bash)" >> /root/.bashrc
-        echo "alias k=kubectl" >> /root/.bashrc
-        echo "complete -o default -F __start_kubectl k" >> /root/.bashrc
       fi
+      rm /run/metadata.json
     preKubeadmCommands:
     - |
       sed -ri '/\sswap\s/s/^#?/#/' /etc/fstab
@@ -194,12 +192,12 @@ spec:
       sed -i 's/SystemdCgroup = false/SystemdCgroup = true/' /etc/containerd/config.toml
       sed -i "s,sandbox_image.*$,sandbox_image = \"$(kubeadm config images list | grep pause | sort -r | head -n1)\"," /etc/containerd/config.toml
       systemctl restart containerd
+      curl -o /run/metadata.json -fsSL https://metadata.platformequinix.com/metadata
+      for i in $(cat /run/metadata.json | jq -r '.bgp_neighbors[0].peer_ips[]'); do
+        ip route add $i via $(cat /run/metadata.json | jq -r '.network.addresses[] | select(.public == false and .address_family == 4) | .gateway')
+      done
       if [ -f "/run/kubeadm/kubeadm.yaml" ]; then
         ip addr add {{ .controlPlaneEndpoint }} dev lo
-        curl -o /run/metadata.json -fsSL https://metadata.platformequinix.com/metadata
-        for i in $(cat /run/metadata.json | jq -r '.bgp_neighbors[0].peer_ips[]'); do
-          ip route add $i via $(cat /run/metadata.json | jq -r '.network.addresses[] | select(.public == false and .address_family == 4) | .gateway')
-        done
         KVVERSION="${KUBE_VIP_VERSION:=v0.5.0}"
         ctr image pull ghcr.io/kube-vip/kube-vip:$${KVVERSION}
         ctr run --rm --net-host ghcr.io/kube-vip/kube-vip:$KVVERSION vip /kube-vip manifest pod \
@@ -211,7 +209,6 @@ spec:
         --peerAddress $(cat /run/metadata.json | jq -r '.bgp_neighbors[0].peer_ips[0]') \
         --localAS $(cat /run/metadata.json | jq -r '.bgp_neighbors[0].customer_as') \
         --bgpRouterID $(cat /run/metadata.json | jq -r '.bgp_neighbors[0].customer_ip') > /etc/kubernetes/manifests/vip.yaml
-        rm /run/metadata.json
       fi
   machineTemplate:
     infrastructureRef:

--- a/templates/cluster-template.yaml
+++ b/templates/cluster-template.yaml
@@ -82,11 +82,13 @@ spec:
           netmask 255.255.255.255
         EOF
         systemctl restart networking
-        mkdir -p /root/.kube && cp -f /etc/kubernetes/admin.conf /root/.kube/config
-        echo "source <(kubectl completion bash)" >> /root/.bashrc
-        echo "alias k=kubectl" >> /root/.bashrc
-        echo "complete -o default -F __start_kubectl k" >> /root/.bashrc
+        mkdir -p $HOME/.kube
+        cp /etc/kubernetes/admin.conf $HOME/.kube/config
+        echo "source <(kubectl completion bash)" >> $HOME/.bashrc
+        echo "alias k=kubectl" >> $HOME/.bashrc
+        echo "complete -o default -F __start_kubectl k" >> $HOME/.bashrc
         if [ -f "/run/kubeadm/kubeadm.yaml" ]; then
+          export KUBECONFIG=/etc/kubernetes/admin.conf
           export CPEM_YAML=https://github.com/equinix/cloud-provider-equinix-metal/releases/download/${CPEM_VERSION:=v3.5.0}/deployment.yaml
           export SECRET_DATA='cloud-sa.json=''{"apiKey": "{{ .apiKey }}","projectID": "${PROJECT_ID}", "eipTag": "cluster-api-provider-packet:cluster-id:${CLUSTER_NAME}", "eipHealthCheckUseHostIP": true}'''
           kubectl create secret generic -n kube-system metal-cloud-config --from-literal="$${SECRET_DATA}" || (sleep 1 && kubectl create secret generic -n kube-system metal-cloud-config --from-literal="$${SECRET_DATA}") || (sleep 1 && kubectl create secret generic -n kube-system metal-cloud-config --from-literal="$${SECRET_DATA}")

--- a/templates/experimental-kube-vip/kustomization.yaml
+++ b/templates/experimental-kube-vip/kustomization.yaml
@@ -56,12 +56,12 @@ patches:
             sed -i 's/SystemdCgroup = false/SystemdCgroup = true/' /etc/containerd/config.toml
             sed -i "s,sandbox_image.*$,sandbox_image = \"$(kubeadm config images list | grep pause | sort -r | head -n1)\"," /etc/containerd/config.toml
             systemctl restart containerd
+            curl -o /run/metadata.json -fsSL https://metadata.platformequinix.com/metadata
+            for i in $(cat /run/metadata.json | jq -r '.bgp_neighbors[0].peer_ips[]'); do
+              ip route add $i via $(cat /run/metadata.json | jq -r '.network.addresses[] | select(.public == false and .address_family == 4) | .gateway')
+            done
             if [ -f "/run/kubeadm/kubeadm.yaml" ]; then
               ip addr add {{ .controlPlaneEndpoint }} dev lo
-              curl -o /run/metadata.json -fsSL https://metadata.platformequinix.com/metadata
-              for i in $(cat /run/metadata.json | jq -r '.bgp_neighbors[0].peer_ips[]'); do
-                ip route add $i via $(cat /run/metadata.json | jq -r '.network.addresses[] | select(.public == false and .address_family == 4) | .gateway')
-              done
               KVVERSION="${KUBE_VIP_VERSION:=v0.5.0}"
               ctr image pull ghcr.io/kube-vip/kube-vip:$${KVVERSION}
               ctr run --rm --net-host ghcr.io/kube-vip/kube-vip:$KVVERSION vip /kube-vip manifest pod \
@@ -73,15 +73,16 @@ patches:
               --peerAddress $(cat /run/metadata.json | jq -r '.bgp_neighbors[0].peer_ips[0]') \
               --localAS $(cat /run/metadata.json | jq -r '.bgp_neighbors[0].customer_as') \
               --bgpRouterID $(cat /run/metadata.json | jq -r '.bgp_neighbors[0].customer_ip') > /etc/kubernetes/manifests/vip.yaml
-              rm /run/metadata.json
             fi
         postKubeadmCommands:
           - |
-            curl -o /run/metadata.json -fsSL https://metadata.platformequinix.com/metadata
-            for i in $(cat /run/metadata.json | jq -r '.bgp_neighbors[0].peer_ips[]'); do
-              ip route add $i via $(cat /run/metadata.json | jq -r '.network.addresses[] | select(.public == false and .address_family == 4) | .gateway')
-            done
+            mkdir -p $HOME/.kube
+            cp /etc/kubernetes/admin.conf $HOME/.kube/config
+            echo "source <(kubectl completion bash)" >> $HOME/.bashrc
+            echo "alias k=kubectl" >> $HOME/.bashrc
+            echo "complete -o default -F __start_kubectl k" >> $HOME/.bashrc
             if [ -f "/run/kubeadm/kubeadm.yaml" ]; then
+              export KUBECONFIG=/etc/kubernetes/admin.conf
               export CPEM_YAML=https://github.com/equinix/cloud-provider-equinix-metal/releases/download/${CPEM_VERSION:=v3.5.0}/deployment.yaml
               export SECRET_DATA='cloud-sa.json=''{"apiKey": "{{ .apiKey }}","projectID": "${PROJECT_ID}", "loadbalancer": "kube-vip://", "facility": "${FACILITY}"}'''
               kubectl create secret generic -n kube-system metal-cloud-config --from-literal="$${SECRET_DATA}" || (sleep 1 && kubectl create secret generic -n kube-system metal-cloud-config --from-literal="$${SECRET_DATA}") || (sleep 1 && kubectl create secret generic -n kube-system metal-cloud-config --from-literal="$${SECRET_DATA}")
@@ -98,12 +99,8 @@ patches:
               --peerAddress $(cat /run/metadata.json | jq -r '.bgp_neighbors[0].peer_ips[0]') \
               --localAS $(cat /run/metadata.json | jq -r '.bgp_neighbors[0].customer_as') \
               --bgpRouterID $(cat /run/metadata.json | jq -r '.bgp_neighbors[0].customer_ip') > /etc/kubernetes/manifests/vip.yaml
-              rm /run/metadata.json
-              mkdir -p /root/.kube && cp -f /etc/kubernetes/admin.conf /root/.kube/config
-              echo "source <(kubectl completion bash)" >> /root/.bashrc
-              echo "alias k=kubectl" >> /root/.bashrc
-              echo "complete -o default -F __start_kubectl k" >> /root/.bashrc
             fi
+            rm /run/metadata.json
 - patch: |
     kind: KubeadmConfigTemplate
     apiVersion: bootstrap.cluster.x-k8s.io/v1beta1


### PR DESCRIPTION
Fix where the remove of the metadata.json is
Move the crictl/kubectl setup sections for clarity
Add KUBECONFIG definition into the if -f kubeadm.yaml blocks

Signed-off-by: Chris Privitere <23177737+cprivitere@users.noreply.github.com>

**What this PR does / why we need it**: Adds the KUBECONFIG definition back into the cloud init to make end to end tests work again. See issue for details.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #435
