### PR TITLE
:warning: Use Ubuntu 22.04 for testing and default deployments

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ If you do not change the generated `yaml` files, it will use defaults. You can l
 
 * `CPEM_VERSION`                 (defaults to `v3.5.0`)
 * `KUBE_VIP_VERSION`             (defaults to `v0.5.0`)
-* `NODE_OS`                      (defaults to `ubuntu_18_04`)
+* `NODE_OS`                      (defaults to `ubuntu_22_04`)
 * `POD_CIDR`                     (defaults to `192.168.0.0/16`)
 * `SERVICE_CIDR`                 (defaults to `172.26.0.0/16`)
   
@@ -55,7 +55,7 @@ spec:
     spec:
       billingCycle: hourly
       machineType: c3.small.x86
-      os: ubuntu_18_04
+      os: ubuntu_22_04
       sshKeys:
       - ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIDvMgVEubPLztrvVKgNPnRe9sZSjAqaYj9nmCkgr4PdK username@computer
       tags: []

--- a/docs/concepts/machine.md
+++ b/docs/concepts/machine.md
@@ -11,7 +11,7 @@ kind: PacketMachine
 metadata:
   name: "qa-controlplane-0"
 spec:
-  os: "ubuntu_18_04"
+  os: "ubuntu_22_04"
   billingCycle: hourly
   machineType: "c3.small.x86"
   sshKeys:

--- a/templates/cluster-template-crs-cni.yaml
+++ b/templates/cluster-template-crs-cni.yaml
@@ -238,7 +238,7 @@ spec:
     spec:
       billingCycle: hourly
       machineType: ${CONTROLPLANE_NODE_TYPE}
-      os: ${NODE_OS:=ubuntu_18_04}
+      os: ${NODE_OS:=ubuntu_22_04}
       sshKeys:
       - ${SSH_KEY}
       tags: []
@@ -252,7 +252,7 @@ spec:
     spec:
       billingCycle: hourly
       machineType: ${WORKER_NODE_TYPE}
-      os: ${NODE_OS:=ubuntu_18_04}
+      os: ${NODE_OS:=ubuntu_22_04}
       sshKeys:
       - ${SSH_KEY}
       tags: []

--- a/templates/cluster-template-kube-vip-crs-cni.yaml
+++ b/templates/cluster-template-kube-vip-crs-cni.yaml
@@ -257,7 +257,7 @@ spec:
     spec:
       billingCycle: hourly
       machineType: ${CONTROLPLANE_NODE_TYPE}
-      os: ${NODE_OS:=ubuntu_18_04}
+      os: ${NODE_OS:=ubuntu_22_04}
       sshKeys:
       - ${SSH_KEY}
       tags: []
@@ -271,7 +271,7 @@ spec:
     spec:
       billingCycle: hourly
       machineType: ${WORKER_NODE_TYPE}
-      os: ${NODE_OS:=ubuntu_18_04}
+      os: ${NODE_OS:=ubuntu_22_04}
       sshKeys:
       - ${SSH_KEY}
       tags: []

--- a/templates/cluster-template-kube-vip.yaml
+++ b/templates/cluster-template-kube-vip.yaml
@@ -236,7 +236,7 @@ spec:
     spec:
       billingCycle: hourly
       machineType: ${CONTROLPLANE_NODE_TYPE}
-      os: ${NODE_OS:=ubuntu_18_04}
+      os: ${NODE_OS:=ubuntu_22_04}
       sshKeys:
       - ${SSH_KEY}
       tags: []
@@ -250,7 +250,7 @@ spec:
     spec:
       billingCycle: hourly
       machineType: ${WORKER_NODE_TYPE}
-      os: ${NODE_OS:=ubuntu_18_04}
+      os: ${NODE_OS:=ubuntu_22_04}
       sshKeys:
       - ${SSH_KEY}
       tags: []

--- a/templates/cluster-template.yaml
+++ b/templates/cluster-template.yaml
@@ -102,7 +102,7 @@ metadata:
 spec:
   template:
     spec:
-      os: "${NODE_OS:=ubuntu_18_04}"
+      os: "${NODE_OS:=ubuntu_22_04}"
       billingCycle: hourly
       machineType: "${CONTROLPLANE_NODE_TYPE}"
       sshKeys:
@@ -178,7 +178,7 @@ metadata:
 spec:
   template:
     spec:
-      os: "${NODE_OS:=ubuntu_18_04}"
+      os: "${NODE_OS:=ubuntu_22_04}"
       billingCycle: hourly
       machineType: "${WORKER_NODE_TYPE}"
       sshKeys:

--- a/test/e2e/config/packet-ci-actions.yaml
+++ b/test/e2e/config/packet-ci-actions.yaml
@@ -158,7 +158,7 @@ variables:
   COREDNS_VERSION_UPGRADE_TO: "v1.8.6"
 
   # Infra provider specific variables
-  NODE_OS: "ubuntu_18_04"
+  NODE_OS: "ubuntu_22_04"
   POD_CIDR: "192.168.0.0/16"
   SERVICE_CIDR: "172.26.0.0/16"
 

--- a/test/e2e/config/packet-ci.yaml
+++ b/test/e2e/config/packet-ci.yaml
@@ -165,7 +165,7 @@ variables:
   COREDNS_VERSION_UPGRADE_TO: "v1.8.6"
 
   # Infra provider specific variables
-  NODE_OS: "ubuntu_18_04"
+  NODE_OS: "ubuntu_22_04"
   POD_CIDR: "192.168.0.0/16"
   SERVICE_CIDR: "172.26.0.0/16"
 

--- a/test/e2e/data/v1alpha3/bases/cluster-with-kcp-cpem.yaml
+++ b/test/e2e/data/v1alpha3/bases/cluster-with-kcp-cpem.yaml
@@ -43,7 +43,7 @@ metadata:
 spec:
   template:
     spec:
-      OS: "${NODE_OS:=ubuntu_18_04}"
+      OS: "${NODE_OS:=ubuntu_22_04}"
       billingCycle: hourly
       machineType: "${CONTROLPLANE_NODE_TYPE}"
       sshKeys:

--- a/test/e2e/data/v1alpha3/bases/cluster-with-kcp-packet-ccm.yaml
+++ b/test/e2e/data/v1alpha3/bases/cluster-with-kcp-packet-ccm.yaml
@@ -43,7 +43,7 @@ metadata:
 spec:
   template:
     spec:
-      OS: "${NODE_OS:=ubuntu_18_04}"
+      OS: "${NODE_OS:=ubuntu_22_04}"
       billingCycle: hourly
       machineType: "${CONTROLPLANE_NODE_TYPE}"
       sshKeys:

--- a/test/e2e/data/v1alpha3/bases/md.yaml
+++ b/test/e2e/data/v1alpha3/bases/md.yaml
@@ -7,7 +7,7 @@ metadata:
 spec:
   template:
     spec:
-      OS: "${NODE_OS:=ubuntu_18_04}"
+      OS: "${NODE_OS:=ubuntu_22_04}"
       billingCycle: hourly
       machineType: "${WORKER_NODE_TYPE}"
       sshKeys:


### PR DESCRIPTION
Signed-off-by: Chris Privitere <23177737+cprivitere@users.noreply.github.com>

**What this PR does / why we need it**: Use Ubuntu 22.04 as the default deployment OS and the testing OS. Equinix Metal will be disabling 18.04 in April.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
