### PR TITLE
🏃 :sparkles: Add-metro-support

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -196,7 +196,7 @@ jobs:
         E2E_CONF_FILE_SOURCE: "${{ github.workspace }}/test/e2e/config/packet-ci-actions.yaml"
         SKIP_IMAGE_BUILD: "1"
         MANIFEST_PATH: "../../../out/release"
-        FACILITY: da11
+        METRO: da
         CONTROLPLANE_NODE_TYPE: c3.medium.x86
         WORKER_NODE_TYPE: c3.medium.x86
         GINKGO_NODES: "1"
@@ -254,7 +254,7 @@ jobs:
         E2E_CONF_FILE_SOURCE: "${{ github.workspace }}/test/e2e/config/packet-ci-actions.yaml"
         SKIP_IMAGE_BUILD: "1"
         MANIFEST_PATH: "../../../out/release"
-        FACILITY: da11
+        METRO: da
         CONTROLPLANE_NODE_TYPE: c3.medium.x86
         WORKER_NODE_TYPE: c3.medium.x86
         GINKGO_NODES: "1"
@@ -312,7 +312,7 @@ jobs:
         E2E_CONF_FILE_SOURCE: "${{ github.workspace }}/test/e2e/config/packet-ci-actions.yaml"
         SKIP_IMAGE_BUILD: "1"
         MANIFEST_PATH: "../../../out/release"
-        FACILITY: da11
+        METRO: da
         CONTROLPLANE_NODE_TYPE: c3.medium.x86
         WORKER_NODE_TYPE: c3.medium.x86
         GINKGO_NODES: "1"
@@ -370,7 +370,7 @@ jobs:
         E2E_CONF_FILE_SOURCE: "${{ github.workspace }}/test/e2e/config/packet-ci-actions.yaml"
         SKIP_IMAGE_BUILD: "1"
         MANIFEST_PATH: "../../../out/release"
-        FACILITY: da11
+        METRO: da
         CONTROLPLANE_NODE_TYPE: c3.medium.x86
         WORKER_NODE_TYPE: c3.medium.x86
         GINKGO_NODES: "1"
@@ -428,7 +428,7 @@ jobs:
         E2E_CONF_FILE_SOURCE: "${{ github.workspace }}/test/e2e/config/packet-ci-actions.yaml"
         SKIP_IMAGE_BUILD: "1"
         MANIFEST_PATH: "../../../out/release"
-        FACILITY: da11
+        METRO: da
         CONTROLPLANE_NODE_TYPE: c3.medium.x86
         WORKER_NODE_TYPE: c3.medium.x86
         GINKGO_NODES: "1"

--- a/README.md
+++ b/README.md
@@ -10,6 +10,17 @@ This is the official [cluster-api](https://github.com/kubernetes-sigs/cluster-ap
 
 ![Packetbot works hard to keep Kubernetes cluster in a good shape](./docs/banner.png)
 
+## Ugrading to v0.7.X
+
+**IMPORTANT** Before you upgrade, please note that Facilities have been deprecated as of version v0.7.0
+
+* Newly generated cluster yaml files will use Metro by default.
+* Facility is still usable, but should be moved away from as soon as you can
+* See here for more info on the facility deprecation: [Bye Facilities, Hello (again) Metros](https://feedback.equinixmetal.com/changelog/bye-facilities-hello-again-metros)
+* If you would like to upgrade your existing clusters from using facilities to using metros, please work with your Equinix support team to figure out the best course of action. We can also provide some support via our [community Slack](https://slack.equinixmetal.com/) and the [Equinix Helix community site](https://community.equinix.com/).
+* The basic requirement will be to replace `facility: sv15` with `metro: sv` (insert your correct metro instead of sv, for more information check out our [Metros documentation](https://deploy.equinix.com/developers/docs/metal/locations/metros/)) in your existing PacketCluster and PacketMachine objects and/or yaml files used to reconcile those objects (if you're say, managing them via GitOps)
+* The expectation is that if the devices are already in the correct metros you've specified, no disruption will happen to clusters or their devices.
+
 ## Requirements
 
 To use the cluster-api to deploy a Kubernetes cluster to Equinix Metal, you need the following:

--- a/README.md
+++ b/README.md
@@ -18,8 +18,8 @@ This is the official [cluster-api](https://github.com/kubernetes-sigs/cluster-ap
 * Facility is still usable, but should be moved away from as soon as you can
 * See here for more info on the facility deprecation: [Bye Facilities, Hello (again) Metros](https://feedback.equinixmetal.com/changelog/bye-facilities-hello-again-metros)
 * If you would like to upgrade your existing clusters from using facilities to using metros, please work with your Equinix support team to figure out the best course of action. We can also provide some support via our [community Slack](https://slack.equinixmetal.com/) and the [Equinix Helix community site](https://community.equinix.com/).
-* The basic requirement will be to replace `facility: sv15` with `metro: sv` (insert your correct metro instead of sv, for more information check out our [Metros documentation](https://deploy.equinix.com/developers/docs/metal/locations/metros/)) in your existing PacketCluster and PacketMachine objects and/or yaml files used to reconcile those objects (if you're say, managing them via GitOps)
-* The expectation is that if the devices are already in the correct metros you've specified, no disruption will happen to clusters or their devices.
+* The basic process will be to upgrade to v0.7.0, then replace `facility: sv15` with `metro: sv` (insert your correct metro instead of sv, for more information check out our [Metros documentation](https://deploy.equinix.com/developers/docs/metal/locations/metros/)) in your existing PacketCluster and PacketMachine objects and/or yaml files used to reconcile those objects (if you're say, managing them via GitOps)
+* The expectation is that if the devices are already in the correct metros you've specified, no disruption will happen to clusters or their devices, however, **as with any breaking change you should verify this outside of production before you upgrade.**
 
 ## Requirements
 

--- a/api/v1alpha3/packetcluster_types.go
+++ b/api/v1alpha3/packetcluster_types.go
@@ -32,6 +32,10 @@ type PacketClusterSpec struct {
 	// Facility represents the Packet facility for this cluster
 	Facility string `json:"facility,omitempty"`
 
+	// Metro represents the Packet metro for this cluster
+	// +optional
+	Metro string `json:"metro,omitempty"`
+
 	// ControlPlaneEndpoint represents the endpoint used to communicate with the control plane.
 	// +optional
 	ControlPlaneEndpoint clusterv1.APIEndpoint `json:"controlPlaneEndpoint"`

--- a/api/v1alpha3/packetcluster_types.go
+++ b/api/v1alpha3/packetcluster_types.go
@@ -30,6 +30,7 @@ type PacketClusterSpec struct {
 	ProjectID string `json:"projectID"`
 
 	// Facility represents the Packet facility for this cluster
+	// +optional
 	Facility string `json:"facility,omitempty"`
 
 	// Metro represents the Packet metro for this cluster

--- a/api/v1alpha3/packetmachine_types.go
+++ b/api/v1alpha3/packetmachine_types.go
@@ -41,6 +41,7 @@ type PacketMachineSpec struct {
 	Facility string `json:"facility,omitempty"`
 
 	// Metro represents the Packet metro for this cluster
+	// Override from the PacketCluster spec.
 	// +optional
 	Metro string `json:"metro,omitempty"`
 

--- a/api/v1alpha3/packetmachine_types.go
+++ b/api/v1alpha3/packetmachine_types.go
@@ -40,6 +40,10 @@ type PacketMachineSpec struct {
 	// +optional
 	Facility string `json:"facility,omitempty"`
 
+	// Metro represents the Packet metro for this cluster
+	// +optional
+	Metro string `json:"metro,omitempty"`
+
 	// IPXEUrl can be used to set the pxe boot url when using custom OSes with this provider.
 	// Note that OS should also be set to "custom_ipxe" if using this value.
 	// +optional

--- a/api/v1alpha3/zz_generated.conversion.go
+++ b/api/v1alpha3/zz_generated.conversion.go
@@ -238,6 +238,7 @@ func Convert_v1beta1_PacketClusterList_To_v1alpha3_PacketClusterList(in *v1beta1
 func autoConvert_v1alpha3_PacketClusterSpec_To_v1beta1_PacketClusterSpec(in *PacketClusterSpec, out *v1beta1.PacketClusterSpec, s conversion.Scope) error {
 	out.ProjectID = in.ProjectID
 	out.Facility = in.Facility
+	out.Metro = in.Metro
 	if err := apiv1alpha3.Convert_v1alpha3_APIEndpoint_To_v1beta1_APIEndpoint(&in.ControlPlaneEndpoint, &out.ControlPlaneEndpoint, s); err != nil {
 		return err
 	}
@@ -253,6 +254,7 @@ func Convert_v1alpha3_PacketClusterSpec_To_v1beta1_PacketClusterSpec(in *PacketC
 func autoConvert_v1beta1_PacketClusterSpec_To_v1alpha3_PacketClusterSpec(in *v1beta1.PacketClusterSpec, out *PacketClusterSpec, s conversion.Scope) error {
 	out.ProjectID = in.ProjectID
 	out.Facility = in.Facility
+	out.Metro = in.Metro
 	if err := apiv1alpha3.Convert_v1beta1_APIEndpoint_To_v1alpha3_APIEndpoint(&in.ControlPlaneEndpoint, &out.ControlPlaneEndpoint, s); err != nil {
 		return err
 	}
@@ -361,6 +363,7 @@ func autoConvert_v1alpha3_PacketMachineSpec_To_v1beta1_PacketMachineSpec(in *Pac
 	out.MachineType = in.MachineType
 	// WARNING: in.SshKeys requires manual conversion: does not exist in peer-type
 	out.Facility = in.Facility
+	out.Metro = in.Metro
 	out.IPXEUrl = in.IPXEUrl
 	out.HardwareReservationID = in.HardwareReservationID
 	out.ProviderID = (*string)(unsafe.Pointer(in.ProviderID))
@@ -374,6 +377,7 @@ func autoConvert_v1beta1_PacketMachineSpec_To_v1alpha3_PacketMachineSpec(in *v1b
 	out.MachineType = in.MachineType
 	// WARNING: in.SSHKeys requires manual conversion: does not exist in peer-type
 	out.Facility = in.Facility
+	out.Metro = in.Metro
 	out.IPXEUrl = in.IPXEUrl
 	out.HardwareReservationID = in.HardwareReservationID
 	out.ProviderID = (*string)(unsafe.Pointer(in.ProviderID))

--- a/api/v1beta1/packetcluster_types.go
+++ b/api/v1beta1/packetcluster_types.go
@@ -35,6 +35,7 @@ type PacketClusterSpec struct {
 	ProjectID string `json:"projectID"`
 
 	// Facility represents the Packet facility for this cluster
+	// +optional
 	Facility string `json:"facility,omitempty"`
 
 	// Metro represents the Packet metro for this cluster

--- a/api/v1beta1/packetcluster_types.go
+++ b/api/v1beta1/packetcluster_types.go
@@ -37,6 +37,10 @@ type PacketClusterSpec struct {
 	// Facility represents the Packet facility for this cluster
 	Facility string `json:"facility,omitempty"`
 
+	// Metro represents the Packet metro for this cluster
+	// +optional
+	Metro string `json:"metro,omitempty"`
+
 	// ControlPlaneEndpoint represents the endpoint used to communicate with the control plane.
 	// +optional
 	ControlPlaneEndpoint clusterv1.APIEndpoint `json:"controlPlaneEndpoint"`

--- a/api/v1beta1/packetcluster_webhook.go
+++ b/api/v1beta1/packetcluster_webhook.go
@@ -85,6 +85,22 @@ func (c *PacketCluster) ValidateUpdate(oldRaw runtime.Object) error {
 		)
 	}
 
+	// Must have either one of Metro or Facility
+	if len(c.Spec.Facility) == 0 && len(c.Spec.Metro) == 0 {
+		allErrs = append(allErrs,
+			field.Invalid(field.NewPath("spec", "Metro"),
+				c.Spec.Metro, "field is required when Facility is not set"),
+		)
+	}
+
+	// Must not have both Metro and Facility
+	if len(c.Spec.Facility) > 0 && len(c.Spec.Metro) > 0 {
+		allErrs = append(allErrs,
+			field.Invalid(field.NewPath("spec", "Facility"),
+				c.Spec.Facility, "field is mutually exclusive with Metro"),
+		)
+	}
+
 	if len(allErrs) == 0 {
 		return nil
 	}

--- a/api/v1beta1/packetcluster_webhook.go
+++ b/api/v1beta1/packetcluster_webhook.go
@@ -88,11 +88,19 @@ func (c *PacketCluster) ValidateUpdate(oldRaw runtime.Object) error {
 		)
 	}
 
-	// Must have either one of Metro or Facility
+	// Must have at least Metro or Facility specified
 	if len(c.Spec.Facility) == 0 && len(c.Spec.Metro) == 0 {
 		allErrs = append(allErrs,
 			field.Invalid(field.NewPath("spec", "Metro"),
 				c.Spec.Metro, "field is required when Facility is not set"),
+		)
+	}
+
+	// Must have only one of Metro or Facility
+	if len(c.Spec.Facility) > 0 && len(c.Spec.Metro) > 0 {
+		allErrs = append(allErrs,
+			field.Invalid(field.NewPath("spec", "Metro"),
+				c.Spec.Metro, "field and Facility field are mutually exclusive"),
 		)
 	}
 

--- a/api/v1beta1/packetcluster_webhook.go
+++ b/api/v1beta1/packetcluster_webhook.go
@@ -92,15 +92,15 @@ func (c *PacketCluster) ValidateUpdate(oldRaw runtime.Object) error {
 	if len(c.Spec.Facility) == 0 && len(c.Spec.Metro) == 0 {
 		allErrs = append(allErrs,
 			field.Invalid(field.NewPath("spec", "Metro"),
-				c.Spec.Metro, "field is required when Facility is not set"),
+				c.Spec.Metro, "Metro is required when Facility is not set"),
 		)
 	}
 
 	// Must have only one of Metro or Facility
 	if len(c.Spec.Facility) > 0 && len(c.Spec.Metro) > 0 {
 		allErrs = append(allErrs,
-			field.Invalid(field.NewPath("spec", "Metro"),
-				c.Spec.Metro, "field and Facility field are mutually exclusive"),
+			field.Invalid(field.NewPath("spec", "Facility"),
+				c.Spec.Facility, "Metro and Facility are mutually exclusive"),
 		)
 	}
 

--- a/api/v1beta1/packetcluster_webhook.go
+++ b/api/v1beta1/packetcluster_webhook.go
@@ -53,13 +53,9 @@ func (c *PacketCluster) ValidateCreate() error {
 	if len(c.Spec.Facility) == 0 && len(c.Spec.Metro) == 0 {
 		allErrs = append(allErrs,
 			field.Invalid(field.NewPath("spec", "Metro"),
-				c.Spec.Metro, "field is required when Facility is not set"),
+				c.Spec.Metro, "field is required"),
 		)
 	}
-
-	// If both Metro and Facility are set, ignore Facility, we'll leave this to
-	// the controller to deal with - the facility will need to reside in the
-	// metro.
 
 	if len(allErrs) > 0 {
 		return apierrors.NewInvalid(GroupVersion.WithKind("PacketCluster").GroupKind(), c.Name, allErrs)
@@ -92,7 +88,7 @@ func (c *PacketCluster) ValidateUpdate(oldRaw runtime.Object) error {
 	if len(c.Spec.Facility) == 0 && len(c.Spec.Metro) == 0 {
 		allErrs = append(allErrs,
 			field.Invalid(field.NewPath("spec", "Metro"),
-				c.Spec.Metro, "Metro is required when Facility is not set"),
+				c.Spec.Metro, "Metro is required"),
 		)
 	}
 
@@ -100,7 +96,7 @@ func (c *PacketCluster) ValidateUpdate(oldRaw runtime.Object) error {
 	if len(c.Spec.Facility) > 0 && len(c.Spec.Metro) > 0 {
 		allErrs = append(allErrs,
 			field.Invalid(field.NewPath("spec", "Facility"),
-				c.Spec.Facility, "Metro and Facility are mutually exclusive"),
+				c.Spec.Facility, "Metro and Facility are mutually exclusive, Metro is recommended"),
 		)
 	}
 

--- a/api/v1beta1/packetcluster_webhook.go
+++ b/api/v1beta1/packetcluster_webhook.go
@@ -93,12 +93,9 @@ func (c *PacketCluster) ValidateUpdate(oldRaw runtime.Object) error {
 		)
 	}
 
-	// Must not have both Metro and Facility
+	// If both Metro and Facility are set, ignore Facility
 	if len(c.Spec.Facility) > 0 && len(c.Spec.Metro) > 0 {
-		allErrs = append(allErrs,
-			field.Invalid(field.NewPath("spec", "Facility"),
-				c.Spec.Facility, "field is mutually exclusive with Metro"),
-		)
+		clusterlog.Info("Metro and Facility are both set, ignoring Facility.")
 	}
 
 	if len(allErrs) == 0 {

--- a/api/v1beta1/packetcluster_webhook.go
+++ b/api/v1beta1/packetcluster_webhook.go
@@ -71,6 +71,13 @@ func (c *PacketCluster) ValidateUpdate(oldRaw runtime.Object) error {
 		)
 	}
 
+	if !reflect.DeepEqual(c.Spec.Metro, old.Spec.Metro) {
+		allErrs = append(allErrs,
+			field.Invalid(field.NewPath("spec", "Metro"),
+				c.Spec.Metro, "field is immutable"),
+		)
+	}
+
 	if !reflect.DeepEqual(c.Spec.VIPManager, old.Spec.VIPManager) {
 		allErrs = append(allErrs,
 			field.Invalid(field.NewPath("spec", "VIPManager"),

--- a/api/v1beta1/packetmachine_types.go
+++ b/api/v1beta1/packetmachine_types.go
@@ -63,7 +63,7 @@ type PacketMachineSpec struct {
 	// +optional
 	Facility string `json:"facility,omitempty"`
 
-	// Metro represents the Packet metro for this cluster
+	// Metro represents the Packet metro for this machine
 	// Override from the PacketCluster spec.
 	// +optional
 	Metro string `json:"metro,omitempty"`

--- a/api/v1beta1/packetmachine_types.go
+++ b/api/v1beta1/packetmachine_types.go
@@ -64,6 +64,7 @@ type PacketMachineSpec struct {
 	Facility string `json:"facility,omitempty"`
 
 	// Metro represents the Packet metro for this cluster
+	// Override from the PacketCluster spec.
 	// +optional
 	Metro string `json:"metro,omitempty"`
 

--- a/api/v1beta1/packetmachine_types.go
+++ b/api/v1beta1/packetmachine_types.go
@@ -63,6 +63,10 @@ type PacketMachineSpec struct {
 	// +optional
 	Facility string `json:"facility,omitempty"`
 
+	// Metro represents the Packet metro for this cluster
+	// +optional
+	Metro string `json:"metro,omitempty"`
+
 	// IPXEUrl can be used to set the pxe boot url when using custom OSes with this provider.
 	// Note that OS should also be set to "custom_ipxe" if using this value.
 	// +optional

--- a/api/v1beta1/packetmachine_webhook.go
+++ b/api/v1beta1/packetmachine_webhook.go
@@ -63,8 +63,8 @@ func (m *PacketMachine) ValidateUpdate(old runtime.Object) error {
 	// Must have only one of Metro or Facility specified
 	if len(m.Spec.Facility) > 0 && len(m.Spec.Metro) > 0 {
 		allErrs = append(allErrs,
-			field.Invalid(field.NewPath("spec", "Metro"),
-				m.Spec.Metro, "field and Facility field are mutually exclusive"),
+			field.Invalid(field.NewPath("spec", "Facility"),
+				m.Spec.Facility, "Metro and Facility field are mutually exclusive"),
 		)
 	}
 

--- a/api/v1beta1/packetmachine_webhook.go
+++ b/api/v1beta1/packetmachine_webhook.go
@@ -60,6 +60,14 @@ func (m *PacketMachine) ValidateUpdate(old runtime.Object) error {
 	machineLog.Info("validate update", "name", m.Name)
 	var allErrs field.ErrorList
 
+	// Must have only one of Metro or Facility specified
+	if len(m.Spec.Facility) > 0 && len(m.Spec.Metro) > 0 {
+		allErrs = append(allErrs,
+			field.Invalid(field.NewPath("spec", "Metro"),
+				m.Spec.Metro, "field and Facility field are mutually exclusive"),
+		)
+	}
+
 	newPacketMachine, err := runtime.DefaultUnstructuredConverter.ToUnstructured(m)
 	if err != nil {
 		allErrs = append(allErrs,

--- a/api/v1beta1/packetmachine_webhook.go
+++ b/api/v1beta1/packetmachine_webhook.go
@@ -61,6 +61,17 @@ func (m *PacketMachine) ValidateUpdate(old runtime.Object) error {
 		})
 	}
 
+	// Either Metro or Facility must be set, but not both
+	if m.Spec.Metro != "" && m.Spec.Facility != "" {
+		return apierrors.NewInvalid(GroupVersion.WithKind("PacketMachine").GroupKind(), m.Name, field.ErrorList{
+			field.Forbidden(field.NewPath("spec", "metro"), "cannot be set when spec.facility is set"),
+		})
+	} else if m.Spec.Metro == "" && m.Spec.Facility == "" {
+		return apierrors.NewInvalid(GroupVersion.WithKind("PacketMachine").GroupKind(), m.Name, field.ErrorList{
+			field.Required(field.NewPath("spec", "metro"), "must be set when spec.facility is not set"),
+		})
+	}
+
 	newPacketMachineSpec, _ := newPacketMachine["spec"].(map[string]interface{})
 	oldPacketMachineSpec, _ := oldPacketMachine["spec"].(map[string]interface{})
 

--- a/api/v1beta1/packetmachine_webhook.go
+++ b/api/v1beta1/packetmachine_webhook.go
@@ -42,15 +42,6 @@ func (m *PacketMachine) SetupWebhookWithManager(mgr ctrl.Manager) error {
 // ValidateCreate implements webhook.Validator so a webhook will be registered for the type.
 func (m *PacketMachine) ValidateCreate() error {
 	machineLog.Info("validate create", "name", m.Name)
-	allErrs := field.ErrorList{}
-
-	// If both Metro and Facility are set, ignore Facility, we'll leave this to
-	// the controller to deal with - the facility will need to reside in the
-	// metro.
-
-	if len(allErrs) > 0 {
-		return apierrors.NewInvalid(GroupVersion.WithKind("PacketMachine").GroupKind(), m.Name, allErrs)
-	}
 
 	return nil
 }

--- a/config/crd/bases/infrastructure.cluster.x-k8s.io_packetclusters.yaml
+++ b/config/crd/bases/infrastructure.cluster.x-k8s.io_packetclusters.yaml
@@ -64,6 +64,9 @@ spec:
               facility:
                 description: Facility represents the Packet facility for this cluster
                 type: string
+              metro:
+                description: Metro represents the Packet metro for this cluster
+                type: string
               projectID:
                 description: ProjectID represents the Packet Project where this cluster
                   will be placed into
@@ -138,6 +141,9 @@ spec:
                 type: object
               facility:
                 description: Facility represents the Packet facility for this cluster
+                type: string
+              metro:
+                description: Metro represents the Packet metro for this cluster
                 type: string
               projectID:
                 description: ProjectID represents the Packet Project where this cluster

--- a/config/crd/bases/infrastructure.cluster.x-k8s.io_packetmachines.yaml
+++ b/config/crd/bases/infrastructure.cluster.x-k8s.io_packetmachines.yaml
@@ -78,6 +78,9 @@ spec:
                 type: string
               machineType:
                 type: string
+              metro:
+                description: Metro represents the Packet metro for this cluster
+                type: string
               providerID:
                 description: ProviderID is the unique identifier as specified by the
                   cloud provider.
@@ -208,6 +211,9 @@ spec:
                   to "custom_ipxe" if using this value.
                 type: string
               machineType:
+                type: string
+              metro:
+                description: Metro represents the Packet metro for this cluster
                 type: string
               os:
                 type: string

--- a/config/crd/bases/infrastructure.cluster.x-k8s.io_packetmachines.yaml
+++ b/config/crd/bases/infrastructure.cluster.x-k8s.io_packetmachines.yaml
@@ -79,7 +79,8 @@ spec:
               machineType:
                 type: string
               metro:
-                description: Metro represents the Packet metro for this cluster
+                description: Metro represents the Packet metro for this cluster Override
+                  from the PacketCluster spec.
                 type: string
               providerID:
                 description: ProviderID is the unique identifier as specified by the
@@ -213,7 +214,8 @@ spec:
               machineType:
                 type: string
               metro:
-                description: Metro represents the Packet metro for this cluster
+                description: Metro represents the Packet metro for this cluster Override
+                  from the PacketCluster spec.
                 type: string
               os:
                 type: string

--- a/config/crd/bases/infrastructure.cluster.x-k8s.io_packetmachines.yaml
+++ b/config/crd/bases/infrastructure.cluster.x-k8s.io_packetmachines.yaml
@@ -214,7 +214,7 @@ spec:
               machineType:
                 type: string
               metro:
-                description: Metro represents the Packet metro for this cluster Override
+                description: Metro represents the Packet metro for this machine Override
                   from the PacketCluster spec.
                 type: string
               os:

--- a/config/crd/bases/infrastructure.cluster.x-k8s.io_packetmachinetemplates.yaml
+++ b/config/crd/bases/infrastructure.cluster.x-k8s.io_packetmachinetemplates.yaml
@@ -148,7 +148,7 @@ spec:
                       machineType:
                         type: string
                       metro:
-                        description: Metro represents the Packet metro for this cluster
+                        description: Metro represents the Packet metro for this machine
                           Override from the PacketCluster spec.
                         type: string
                       os:

--- a/config/crd/bases/infrastructure.cluster.x-k8s.io_packetmachinetemplates.yaml
+++ b/config/crd/bases/infrastructure.cluster.x-k8s.io_packetmachinetemplates.yaml
@@ -69,6 +69,7 @@ spec:
                         type: string
                       metro:
                         description: Metro represents the Packet metro for this cluster
+                          Override from the PacketCluster spec.
                         type: string
                       providerID:
                         description: ProviderID is the unique identifier as specified
@@ -148,6 +149,7 @@ spec:
                         type: string
                       metro:
                         description: Metro represents the Packet metro for this cluster
+                          Override from the PacketCluster spec.
                         type: string
                       os:
                         type: string

--- a/config/crd/bases/infrastructure.cluster.x-k8s.io_packetmachinetemplates.yaml
+++ b/config/crd/bases/infrastructure.cluster.x-k8s.io_packetmachinetemplates.yaml
@@ -67,6 +67,9 @@ spec:
                         type: string
                       machineType:
                         type: string
+                      metro:
+                        description: Metro represents the Packet metro for this cluster
+                        type: string
                       providerID:
                         description: ProviderID is the unique identifier as specified
                           by the cloud provider.
@@ -142,6 +145,9 @@ spec:
                           also be set to "custom_ipxe" if using this value.
                         type: string
                       machineType:
+                        type: string
+                      metro:
+                        description: Metro represents the Packet metro for this cluster
                         type: string
                       os:
                         type: string

--- a/controllers/packetcluster_controller.go
+++ b/controllers/packetcluster_controller.go
@@ -117,7 +117,7 @@ func (r *PacketClusterReconciler) reconcileNormal(ctx context.Context, clusterSc
 	switch {
 	case errors.Is(err, packet.ErrControlPlanEndpointNotFound):
 		// There is not an ElasticIP with the right tags, at this point we can create one
-		ip, err := r.PacketClient.CreateIP(clusterScope.Namespace(), clusterScope.Name(), packetCluster.Spec.ProjectID, packetCluster.Spec.Facility)
+		ip, err := r.PacketClient.CreateIP(clusterScope.Namespace(), clusterScope.Name(), packetCluster.Spec.ProjectID, packetCluster.Spec.Facility, packetCluster.Spec.Metro)
 		if err != nil {
 			log.Error(err, "error reserving an ip")
 			return ctrl.Result{}, err

--- a/controllers/packetcluster_controller.go
+++ b/controllers/packetcluster_controller.go
@@ -116,8 +116,19 @@ func (r *PacketClusterReconciler) reconcileNormal(ctx context.Context, clusterSc
 	ipReserv, err := r.PacketClient.GetIPByClusterIdentifier(clusterScope.Namespace(), clusterScope.Name(), packetCluster.Spec.ProjectID)
 	switch {
 	case errors.Is(err, packet.ErrControlPlanEndpointNotFound):
+		// Parse metro and facility from the cluster spec
+		var metro, facility string
+
+		facility = packetCluster.Spec.Facility
+		metro = packetCluster.Spec.Metro
+
+		// If both specified, metro takes precedence over facility
+		if metro != "" {
+			facility = ""
+		}
+
 		// There is not an ElasticIP with the right tags, at this point we can create one
-		ip, err := r.PacketClient.CreateIP(clusterScope.Namespace(), clusterScope.Name(), packetCluster.Spec.ProjectID, packetCluster.Spec.Facility, packetCluster.Spec.Metro)
+		ip, err := r.PacketClient.CreateIP(clusterScope.Namespace(), clusterScope.Name(), packetCluster.Spec.ProjectID, facility, metro)
 		if err != nil {
 			log.Error(err, "error reserving an ip")
 			return ctrl.Result{}, err

--- a/controllers/packetmachine_controller.go
+++ b/controllers/packetmachine_controller.go
@@ -52,7 +52,10 @@ const (
 	force = true
 )
 
-var ErrMissingDevice = errors.New("machine does not exist")
+var (
+	ErrMissingDevice      = errors.New("machine does not exist")
+	ErrFacilityMetroMatch = errors.New("instance facility does not match machine facility")
+)
 
 // PacketMachineReconciler reconciles a PacketMachine object
 type PacketMachineReconciler struct {
@@ -415,7 +418,7 @@ func (r *PacketMachineReconciler) reconcile(ctx context.Context, machineScope *s
 	// If Metro or Facility has changed in the spec, verify that the facility's metro is compatible with the requested spec change.
 
 	if machineScope.PacketMachine.Spec.Facility != "" && machineScope.PacketMachine.Spec.Facility != dev.Facility.Code {
-		return ctrl.Result{}, fmt.Errorf("instance facility does not match machine facility %s: %q != %q", machineScope.Name(), machineScope.PacketMachine.Spec.Facility, dev.Facility.Code)
+		return ctrl.Result{}, fmt.Errorf("%w: %s != %s", ErrFacilityMetroMatch, machineScope.PacketMachine.Spec.Facility, dev.Facility.Code)
 	}
 
 	if machineScope.PacketMachine.Spec.Metro != "" && machineScope.PacketMachine.Spec.Metro != dev.Metro.Code {

--- a/controllers/packetmachine_controller.go
+++ b/controllers/packetmachine_controller.go
@@ -53,8 +53,9 @@ const (
 )
 
 var (
-	ErrMissingDevice      = errors.New("machine does not exist")
-	ErrFacilityMetroMatch = errors.New("instance facility does not match machine facility")
+	ErrMissingDevice = errors.New("machine does not exist")
+	ErrFacilityMatch = errors.New("instance facility does not match machine facility")
+	ErrMetroMatch    = errors.New("instance metro does not match machine metro")
 )
 
 // PacketMachineReconciler reconciles a PacketMachine object
@@ -418,11 +419,11 @@ func (r *PacketMachineReconciler) reconcile(ctx context.Context, machineScope *s
 	// If Metro or Facility has changed in the spec, verify that the facility's metro is compatible with the requested spec change.
 
 	if machineScope.PacketMachine.Spec.Facility != "" && machineScope.PacketMachine.Spec.Facility != dev.Facility.Code {
-		return ctrl.Result{}, fmt.Errorf("%w: %s != %s", ErrFacilityMetroMatch, machineScope.PacketMachine.Spec.Facility, dev.Facility.Code)
+		return ctrl.Result{}, fmt.Errorf("%w: %s != %s", ErrFacilityMatch, machineScope.PacketMachine.Spec.Facility, dev.Facility.Code)
 	}
 
 	if machineScope.PacketMachine.Spec.Metro != "" && machineScope.PacketMachine.Spec.Metro != dev.Metro.Code {
-		return ctrl.Result{}, fmt.Errorf("instance metro does not match machine metro %s: %w", machineScope.Name(), err)
+		return ctrl.Result{}, fmt.Errorf("%w: %s != %s", ErrMetroMatch, machineScope.PacketMachine.Spec.Facility, dev.Facility.Code)
 	}
 
 	return result, nil

--- a/controllers/packetmachine_controller.go
+++ b/controllers/packetmachine_controller.go
@@ -412,6 +412,16 @@ func (r *PacketMachineReconciler) reconcile(ctx context.Context, machineScope *s
 		result = ctrl.Result{}
 	}
 
+	// If Metro or Facility has changed in the spec, verify that the facility's metro is compatible with the requested spec change.
+
+	if machineScope.PacketMachine.Spec.Facility != "" && machineScope.PacketMachine.Spec.Facility != dev.Facility.Code {
+		return ctrl.Result{}, fmt.Errorf("instance facility does not match machine facility %s: %q != %q", machineScope.Name(), machineScope.PacketMachine.Spec.Facility, dev.Facility.Code)
+	}
+
+	if machineScope.PacketMachine.Spec.Metro != "" && machineScope.PacketMachine.Spec.Metro != dev.Metro.Code {
+		return ctrl.Result{}, fmt.Errorf("instance metro does not match machine metro %s: %w", machineScope.Name(), err)
+	}
+
 	return result, nil
 }
 

--- a/pkg/cloud/packet/client.go
+++ b/pkg/cloud/packet/client.go
@@ -142,30 +142,17 @@ func (p *Client) NewDevice(ctx context.Context, req CreateDeviceRequest) (*packn
 
 	// If Metro or Facility are specified at the Machine level, we ignore the
 	// values set at the Cluster level
-	var metro, facility string
+	facility := packetClusterSpec.Facility
+	metro := packetClusterSpec.Metro
 
 	if packetMachineSpec.Facility != "" || packetMachineSpec.Metro != "" {
 		metro = packetMachineSpec.Metro
 		facility = packetMachineSpec.Facility
-		// If both specified, metro takes precedence over facility
-		if metro != "" {
-			facility = ""
-		}
-	} else {
-		// Machine level is empty so set facility and metro to cluster level values
-		facility = packetClusterSpec.Facility
-		metro = packetClusterSpec.Metro
-
-		// If both specified, metro takes precedence over facility
-		if metro != "" {
-			facility = ""
-		}
 	}
 
 	serverCreateOpts := &packngo.DeviceCreateRequest{
 		Hostname:      req.MachineScope.Name(),
 		ProjectID:     packetClusterSpec.ProjectID,
-		Facility:      []string{facility},
 		Metro:         metro,
 		BillingCycle:  packetMachineSpec.BillingCycle,
 		Plan:          packetMachineSpec.MachineType,
@@ -173,6 +160,10 @@ func (p *Client) NewDevice(ctx context.Context, req CreateDeviceRequest) (*packn
 		IPXEScriptURL: packetMachineSpec.IPXEUrl,
 		Tags:          tags,
 		UserData:      userData,
+	}
+
+	if facility != "" {
+		serverCreateOpts.Facility = []string{facility}
 	}
 
 	reservationIDs := strings.Split(packetMachineSpec.HardwareReservationID, ",")

--- a/pkg/cloud/packet/client.go
+++ b/pkg/cloud/packet/client.go
@@ -144,10 +144,17 @@ func (p *Client) NewDevice(ctx context.Context, req CreateDeviceRequest) (*packn
 		facility = req.MachineScope.PacketMachine.Spec.Facility
 	}
 
+	// Allow to override the metro for each PacketMachineTemplate
+	metro := req.MachineScope.PacketCluster.Spec.Metro
+	if req.MachineScope.PacketMachine.Spec.Metro != "" {
+		metro = req.MachineScope.PacketMachine.Spec.Metro
+	}
+
 	serverCreateOpts := &packngo.DeviceCreateRequest{
 		Hostname:      req.MachineScope.Name(),
 		ProjectID:     req.MachineScope.PacketCluster.Spec.ProjectID,
 		Facility:      []string{facility},
+		Metro:         metro,
 		BillingCycle:  req.MachineScope.PacketMachine.Spec.BillingCycle,
 		Plan:          req.MachineScope.PacketMachine.Spec.MachineType,
 		OS:            req.MachineScope.PacketMachine.Spec.OS,
@@ -215,11 +222,12 @@ func (p *Client) GetDeviceByTags(project string, tags []string) (*packngo.Device
 
 // CreateIP reserves an IP via Packet API. The request fails straight if no IP are available for the specified project.
 // This prevent the cluster to become ready.
-func (p *Client) CreateIP(namespace, clusterName, projectID, facility string) (net.IP, error) {
+func (p *Client) CreateIP(namespace, clusterName, projectID, facility, metro string) (net.IP, error) {
 	req := packngo.IPReservationRequest{
 		Type:                   packngo.PublicIPv4,
 		Quantity:               1,
 		Facility:               &facility,
+		Metro:                  &metro,
 		FailOnApprovalRequired: true,
 		Tags:                   []string{generateElasticIPIdentifier(clusterName)},
 	}

--- a/scripts/ci-e2e-capi-conformance.sh
+++ b/scripts/ci-e2e-capi-conformance.sh
@@ -35,7 +35,7 @@ source "${REPO_ROOT}/hack/ensure-go.sh"
 # Verify the required Environment Variables are present.
 : "${PACKET_API_KEY:?Environment variable empty or not defined.}"
 : "${PROJECT_ID:?Environment variable empty or not defined.}"
-: "${FACILITY:?Environment variable empty or not defined.}"
+: "${METRO:?Environment variable empty or not defined.}"
 : "${CONTROLPLANE_NODE_TYPE:?Environment variable empty or not defined.}"
 : "${WORKER_NODE_TYPE:?Environment variable empty or not defined.}"
 

--- a/scripts/ci-e2e-capi-management-upgrade.sh
+++ b/scripts/ci-e2e-capi-management-upgrade.sh
@@ -35,7 +35,7 @@ source "${REPO_ROOT}/hack/ensure-go.sh"
 # Verify the required Environment Variables are present.
 : "${PACKET_API_KEY:?Environment variable empty or not defined.}"
 : "${PROJECT_ID:?Environment variable empty or not defined.}"
-: "${FACILITY:?Environment variable empty or not defined.}"
+: "${METRO:?Environment variable empty or not defined.}"
 : "${CONTROLPLANE_NODE_TYPE:?Environment variable empty or not defined.}"
 : "${WORKER_NODE_TYPE:?Environment variable empty or not defined.}"
 

--- a/scripts/ci-e2e-capi-quickstart.sh
+++ b/scripts/ci-e2e-capi-quickstart.sh
@@ -35,7 +35,7 @@ source "${REPO_ROOT}/hack/ensure-go.sh"
 # Verify the required Environment Variables are present.
 : "${PACKET_API_KEY:?Environment variable empty or not defined.}"
 : "${PROJECT_ID:?Environment variable empty or not defined.}"
-: "${FACILITY:?Environment variable empty or not defined.}"
+: "${METRO:?Environment variable empty or not defined.}"
 : "${CONTROLPLANE_NODE_TYPE:?Environment variable empty or not defined.}"
 : "${WORKER_NODE_TYPE:?Environment variable empty or not defined.}"
 

--- a/scripts/ci-e2e-capi-workload-upgrade.sh
+++ b/scripts/ci-e2e-capi-workload-upgrade.sh
@@ -35,7 +35,7 @@ source "${REPO_ROOT}/hack/ensure-go.sh"
 # Verify the required Environment Variables are present.
 : "${PACKET_API_KEY:?Environment variable empty or not defined.}"
 : "${PROJECT_ID:?Environment variable empty or not defined.}"
-: "${FACILITY:?Environment variable empty or not defined.}"
+: "${METRO:?Environment variable empty or not defined.}"
 : "${CONTROLPLANE_NODE_TYPE:?Environment variable empty or not defined.}"
 : "${WORKER_NODE_TYPE:?Environment variable empty or not defined.}"
 

--- a/scripts/ci-e2e-capi.sh
+++ b/scripts/ci-e2e-capi.sh
@@ -35,7 +35,7 @@ source "${REPO_ROOT}/hack/ensure-go.sh"
 # Verify the required Environment Variables are present.
 : "${PACKET_API_KEY:?Environment variable empty or not defined.}"
 : "${PROJECT_ID:?Environment variable empty or not defined.}"
-: "${FACILITY:?Environment variable empty or not defined.}"
+: "${METRO:?Environment variable empty or not defined.}"
 : "${CONTROLPLANE_NODE_TYPE:?Environment variable empty or not defined.}"
 : "${WORKER_NODE_TYPE:?Environment variable empty or not defined.}"
 

--- a/templates/cluster-template-crs-cni.yaml
+++ b/templates/cluster-template-crs-cni.yaml
@@ -226,6 +226,7 @@ metadata:
   name: ${CLUSTER_NAME}
 spec:
   facility: ${FACILITY}
+  metro: ${METRO}
   projectID: ${PROJECT_ID}
   vipManager: CPEM
 ---

--- a/templates/cluster-template-crs-cni.yaml
+++ b/templates/cluster-template-crs-cni.yaml
@@ -225,7 +225,6 @@ kind: PacketCluster
 metadata:
   name: ${CLUSTER_NAME}
 spec:
-  facility: ${FACILITY}
   metro: ${METRO}
   projectID: ${PROJECT_ID}
   vipManager: CPEM

--- a/templates/cluster-template-kube-vip-crs-cni.yaml
+++ b/templates/cluster-template-kube-vip-crs-cni.yaml
@@ -244,7 +244,6 @@ kind: PacketCluster
 metadata:
   name: ${CLUSTER_NAME}
 spec:
-  facility: ${FACILITY}
   metro: ${METRO}
   projectID: ${PROJECT_ID}
   vipManager: KUBE_VIP

--- a/templates/cluster-template-kube-vip-crs-cni.yaml
+++ b/templates/cluster-template-kube-vip-crs-cni.yaml
@@ -245,6 +245,7 @@ metadata:
   name: ${CLUSTER_NAME}
 spec:
   facility: ${FACILITY}
+  metro: ${METRO}
   projectID: ${PROJECT_ID}
   vipManager: KUBE_VIP
 ---

--- a/templates/cluster-template-kube-vip.yaml
+++ b/templates/cluster-template-kube-vip.yaml
@@ -224,6 +224,7 @@ metadata:
   name: ${CLUSTER_NAME}
 spec:
   facility: ${FACILITY}
+  metro: ${METRO}
   projectID: ${PROJECT_ID}
   vipManager: KUBE_VIP
 ---

--- a/templates/cluster-template-kube-vip.yaml
+++ b/templates/cluster-template-kube-vip.yaml
@@ -223,7 +223,6 @@ kind: PacketCluster
 metadata:
   name: ${CLUSTER_NAME}
 spec:
-  facility: ${FACILITY}
   metro: ${METRO}
   projectID: ${PROJECT_ID}
   vipManager: KUBE_VIP

--- a/templates/cluster-template.yaml
+++ b/templates/cluster-template.yaml
@@ -136,7 +136,6 @@ metadata:
   name: "${CLUSTER_NAME}"
 spec:
   projectID: "${PROJECT_ID}"
-  facility: "${FACILITY}"
   metro: "${METRO}"
   vipManager: "CPEM"
 ---

--- a/templates/cluster-template.yaml
+++ b/templates/cluster-template.yaml
@@ -137,6 +137,7 @@ metadata:
 spec:
   projectID: "${PROJECT_ID}"
   facility: "${FACILITY}"
+  metro: "${METRO}"
   vipManager: "CPEM"
 ---
 apiVersion: cluster.x-k8s.io/v1beta1

--- a/test/e2e/data/v1alpha3/bases/cluster-with-kcp-cpem.yaml
+++ b/test/e2e/data/v1alpha3/bases/cluster-with-kcp-cpem.yaml
@@ -6,7 +6,7 @@ metadata:
   name: '${CLUSTER_NAME}'
 spec:
   projectID: "${PROJECT_ID}"
-  facility: "${FACILITY}"
+  metro: "${METRO}"
 
 ---
 # Cluster object with

--- a/test/e2e/data/v1alpha3/bases/cluster-with-kcp-packet-ccm.yaml
+++ b/test/e2e/data/v1alpha3/bases/cluster-with-kcp-packet-ccm.yaml
@@ -6,7 +6,7 @@ metadata:
   name: '${CLUSTER_NAME}'
 spec:
   projectID: "${PROJECT_ID}"
-  facility: "${FACILITY}"
+  metro: "${METRO}"
 
 ---
 # Cluster object with


### PR DESCRIPTION
Signed-off-by: Moath Qasim <moad.qassem@gmail.com>
Signed-off-by: Chris Privitere <cprivitere@equinix.com>

<!-- please add a icon to the title of this PR (see https://sigs.k8s.io/cluster-api/VERSIONING.md), and delete this line and similar ones -->
<!-- the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, minor or feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🏃 (:running:, other) -->

**What this PR does / why we need it**:
Adding metro support to packet cluster api crds

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:

Fixes #313
Continuation of https://github.com/kubernetes-sigs/cluster-api-provider-packet/pull/448
