### PR TITLE
:bug: Fix linting errors and revert golangci change

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -39,14 +39,6 @@ linters:
     - wsl
 
 linters-settings:
-  godot:
-    #   declarations - for top level declaration comments (default);
-    #   toplevel     - for top level comments;
-    #   all          - for all comments.
-    scope: toplevel
-    exclude:
-    - '^ \+.*'
-    - '^ ANCHOR.*'
   importas:
     # Do not allow unaliased imports of aliased packages.
     # Default: false

--- a/main.go
+++ b/main.go
@@ -13,6 +13,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
+
 package main
 
 import (


### PR DESCRIPTION
Signed-off-by: Chris Privitere <23177737+cprivitere@users.noreply.github.com>

<!-- please add a icon to the title of this PR (see https://sigs.k8s.io/cluster-api/VERSIONING.md), and delete this line and similar ones -->
<!-- the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, minor or feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🏃 (:running:, other) -->

**What this PR does / why we need it**: This PR fixes the go fmt issues that were causing linting errors by adding a line between the top of file comments and the start of the code in main.go. It also backs out the .golangci.yml changes made in the last PR as they were a red herring and did not ignore commenting as thought.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #
