### PR TITLE
:bug: E2e-wrapped-client-fix

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -159,12 +159,12 @@ $(E2E_CONF_FILE): $(ENVSUBST) $(E2E_CONF_FILE_SOURCE)
 run-e2e-tests: $(KUSTOMIZE) $(GINKGO) $(E2E_CONF_FILE) e2e-test-templates $(if $(SKIP_IMAGE_BUILD),,e2e-image) ## Run the e2e tests
 	$(MAKE) set-manifest-image MANIFEST_IMG=$(REGISTRY)/$(IMAGE_NAME) MANIFEST_TAG=$(TAG)
 	$(MAKE) set-manifest-pull-policy PULL_POLICY=IfNotPresent
-	cd test/e2e; time $(GINKGO) -v --trace --progress --tags=e2e \
-		--randomizeAllSpecs -race $(GINKGO_ADDITIONAL_ARGS) \
+	cd test/e2e; time $(GINKGO) -v --trace --tags=e2e \
+		--randomize-all -race $(GINKGO_ADDITIONAL_ARGS) \
 		--focus=$(GINKGO_FOCUS) --skip=$(GINKGO_SKIP) \
-		-nodes=$(GINKGO_NODES) --noColor=$(GINKGO_NOCOLOR) \
+		-nodes=$(GINKGO_NODES) --no-color=$(GINKGO_NOCOLOR) \
 		--output-dir="$(ARTIFACTS)" --junit-report="junit.e2e_suite.1.xml" \
-		--flakeAttempts=$(GINKGO_FLAKE_ATTEMPTS) ./ -- \
+		--flake-attempts=$(GINKGO_FLAKE_ATTEMPTS) ./ -- \
 		-e2e.artifacts-folder="$(ARTIFACTS)" \
 		-e2e.config="$(E2E_CONF_FILE)" \
 		-e2e.skip-resource-cleanup=$(SKIP_CLEANUP) \

--- a/test/e2e/common_test.go
+++ b/test/e2e/common_test.go
@@ -329,13 +329,13 @@ func (wc *wrappedClient) DeleteAllOf(ctx context.Context, obj client.Object, opt
 	return wc.client.DeleteAllOf(ctx, obj, opts...)
 }
 
-func (wc *wrappedClient) Get(ctx context.Context, key client.ObjectKey, obj client.Object) error {
+func (wc *wrappedClient) Get(ctx context.Context, key client.ObjectKey, obj client.Object, opts ...client.GetOption) error {
 	err := wc.recordClusterNameForResource(obj)
 	if err != nil {
 		return err
 	}
 
-	return wc.client.Get(ctx, key, obj)
+	return wc.client.Get(ctx, key, obj, opts...)
 }
 
 func (wc *wrappedClient) List(ctx context.Context, list client.ObjectList, opts ...client.ListOption) error {


### PR DESCRIPTION
Signed-off-by: Chris Privitere <23177737+cprivitere@users.noreply.github.com>

**What this PR does / why we need it**:
Fixes a missing options parameter from the wrapper of the runtime client in the e2e tests. 
Also removes updates deprecated ginkgo flags we were using to avoid warning messages.
