### PR TITLE
:bug: Update metadata.yaml to include definitions for 1.3 and 1.4 capi

### DIFF
--- a/test/e2e/config/packet-ci.yaml
+++ b/test/e2e/config/packet-ci.yaml
@@ -85,7 +85,7 @@ providers:
     files:
     - sourcePath: "../data/shared/v1beta1/metadata.yaml"
   - name: v0.4.8 # latest published release in the v1alpha4 series; this is used for v1alpha4 --> v1beta1 clusterctl upgrades test only.
-    value: "https://github.com/kubernetes-sigs/cluster-api/releases/download/v0.4.7/control-plane-components.yaml"
+    value: "https://github.com/kubernetes-sigs/cluster-api/releases/download/v0.4.8/control-plane-components.yaml"
     type: "url"
     contract: v1alpha4
     replacements:

--- a/test/e2e/data/shared/v1beta1/metadata.yaml
+++ b/test/e2e/data/shared/v1beta1/metadata.yaml
@@ -1,6 +1,16 @@
+# Sync this file to https://github.com/kubernetes-sigs/cluster-api/blob/main/metadata.yaml
 apiVersion: clusterctl.cluster.x-k8s.io/v1alpha3
 kind: Metadata
 releaseSeries:
+  - major: 1
+    minor: 4
+    contract: v1beta1
+  - major: 1
+    minor: 3
+    contract: v1beta1
+  - major: 1
+    minor: 2
+    contract: v1beta1
   - major: 1
     minor: 1
     contract: v1beta1
@@ -13,6 +23,3 @@ releaseSeries:
   - major: 0
     minor: 3
     contract: v1alpha3
-  - major: 0
-    minor: 2
-    contract: v1alpha2


### PR DESCRIPTION
Signed-off-by: Chris Privitere <23177737+cprivitere@users.noreply.github.com>

<!-- please add a icon to the title of this PR (see https://sigs.k8s.io/cluster-api/VERSIONING.md), and delete this line and similar ones -->
<!-- the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, minor or feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🏃 (:running:, other) -->

**What this PR does / why we need it**: This adds 1.4 and 1.3 to the metadata.yaml file that tells clusterctl what version of the API each version of cluster-api uses. This file is used for the e2e tests. 

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #
