### PR TITLE
🐛 Check for non-nil response when enabling BGP

### DIFF
--- a/controllers/packetmachine_controller.go
+++ b/controllers/packetmachine_controller.go
@@ -365,7 +365,7 @@ func (r *PacketMachineReconciler) reconcile(ctx context.Context, machineScope *s
 	if machineScope.PacketCluster.Spec.VIPManager == "KUBE_VIP" {
 		if err := r.PacketClient.EnsureNodeBGPEnabled(dev.ID); err != nil {
 			// Do not treat an error enabling bgp on machine as fatal
-			return ctrl.Result{RequeueAfter: time.Second * 20}, fmt.Errorf("failed to enable bpg on machine %s: %w", machineScope.Name(), err)
+			return ctrl.Result{RequeueAfter: time.Second * 20}, fmt.Errorf("failed to enable bgp on machine %s: %w", machineScope.Name(), err)
 		}
 	}
 

--- a/pkg/cloud/packet/client.go
+++ b/pkg/cloud/packet/client.go
@@ -297,7 +297,7 @@ func (p *Client) EnsureNodeBGPEnabled(id string) error {
 	_, response, err := p.BGPSessions.Create(id, req)
 	// if we already had one, then we can ignore the error
 	// this really should be a 409, but 422 is what is returned
-	if response.StatusCode == 422 && strings.Contains(fmt.Sprintf("%s", err), "already has session") {
+	if response != nil && response.StatusCode == 422 && strings.Contains(fmt.Sprintf("%s", err), "already has session") {
 		err = nil
 	}
 	return err


### PR DESCRIPTION
<!-- please add a icon to the title of this PR (see https://sigs.k8s.io/cluster-api/VERSIONING.md), and delete this line and similar ones -->
<!-- the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, minor or feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🏃 (:running:, other) -->

While testing the metro changes, I ran into a nil pointer exception in the code to ensure that BGP is enabled.  While I can't reliably reproduce that exception, the `p.BGPSession.Create` method (and any other packngo request method) [_is_ capable of returning a nil response](https://github.com/packethost/packngo/blob/master/packngo.go#L193), so we should check for that even if it's rare.
