### PR TITLE
Update e2e intervals

### DIFF
--- a/test/e2e/config/packet-ci-actions.yaml
+++ b/test/e2e/config/packet-ci-actions.yaml
@@ -167,18 +167,14 @@ variables:
   INIT_WITH_KUBERNETES_VERSION: "v1.21.14"
 
 intervals:
+  default/wait-controllers: ["5m", "10s"]
   default/wait-cluster: ["20m", "10s"]
   default/wait-control-plane: ["30m", "10s"]
   default/wait-worker-nodes: ["30m", "10s"]
-  default/wait-controllers: ["5m", "10s"]
   default/wait-delete-cluster: ["20m", "10s"]
-  default/wait-machine-upgrade: ["60m", "10s"]
-  default/wait-machine-status: ["20m", "10s"]
-  default/wait-failed-machine-status: ["2m", "10s"]
-  default/wait-machine-remediation: ["30m", "10s"]
-  default/wait-deployment: ["15m", "10s"]
-  default/wait-deployment-available: ["15m", "10s"]
-  default/wait-job: ["5m", "10s"]
+  default/wait-machine-upgrade: ["120m", "10s"]
   default/wait-nodes-ready: ["10m", "10s"]
-  default/wait-service: ["15m", "10s"]
+  default/wait-machine-remediation: ["30m", "10s"]
+  node-drain/wait-deployment-available: ["15m", "10s"]
+  node-drain/wait-control-plane: ["30m", "10s"]
   node-drain/wait-machine-deleted: ["10m", "10s"]

--- a/test/e2e/config/packet-ci.yaml
+++ b/test/e2e/config/packet-ci.yaml
@@ -172,18 +172,14 @@ variables:
   INIT_WITH_KUBERNETES_VERSION: "v1.21.14"
 
 intervals:
+  default/wait-controllers: ["5m", "10s"]
   default/wait-cluster: ["20m", "10s"]
   default/wait-control-plane: ["30m", "10s"]
   default/wait-worker-nodes: ["30m", "10s"]
-  default/wait-controllers: ["5m", "10s"]
   default/wait-delete-cluster: ["20m", "10s"]
-  default/wait-machine-upgrade: ["60m", "10s"]
-  default/wait-machine-status: ["20m", "10s"]
-  default/wait-failed-machine-status: ["2m", "10s"]
-  default/wait-machine-remediation: ["30m", "10s"]
-  default/wait-deployment: ["15m", "10s"]
-  default/wait-deployment-available: ["15m", "10s"]
-  default/wait-job: ["5m", "10s"]
+  default/wait-machine-upgrade: ["120m", "10s"]
   default/wait-nodes-ready: ["10m", "10s"]
-  default/wait-service: ["15m", "10s"]
+  default/wait-machine-remediation: ["30m", "10s"]
+  node-drain/wait-deployment-available: ["15m", "10s"]
+  node-drain/wait-control-plane: ["30m", "10s"]
   node-drain/wait-machine-deleted: ["10m", "10s"]


### PR DESCRIPTION
Signed-off-by: Chris Privitere <23177737+cprivitere@users.noreply.github.com>

<!-- please add a icon to the title of this PR (see https://sigs.k8s.io/cluster-api/VERSIONING.md), and delete this line and similar ones -->
<!-- the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, minor or feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🏃 (:running:, other) -->

**What this PR does / why we need it**:
Add new intervals from upstream capi
Remove unused intervals
Extend machine-upgrade to 120m instead of 60m

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #
