### PR TITLE
:bug: Update-e2e-harness

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -312,7 +312,7 @@ jobs:
         name: e2e-conformance
         path: _artifacts
   e2e-management-upgrade:
-    name: "E2E management upgrade"
+    name: "E2E Management-Upgrade"
     concurrency: ci-${{ github.ref }}-e2e-management-upgrade
     runs-on: ubuntu-latest
     needs:
@@ -368,7 +368,7 @@ jobs:
         name: e2e-management-upgrade
         path: _artifacts
   e2e-workload-upgrade:
-    name: "E2E workload upgrade"
+    name: "E2E Workload-Upgrade"
     concurrency: ci-${{ github.ref }}-e2e-workload-upgrade
     runs-on: ubuntu-latest
     needs:

--- a/scripts/go_install.sh
+++ b/scripts/go_install.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# Copyright 2020 The Kubernetes Authors.
+# Copyright 2021 The Kubernetes Authors.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -37,7 +37,7 @@ if [ -z "${GOBIN}" ]; then
   exit 1
 fi
 
-rm "${GOBIN}/${2}"* || true
+rm -f "${GOBIN}/${2}"* || true
 
 # install the golang module specified as the first argument
 go install "${1}@${3}"

--- a/test/e2e/capi_e2e_clusterctl_upgrade_test.go
+++ b/test/e2e/capi_e2e_clusterctl_upgrade_test.go
@@ -26,10 +26,10 @@ import (
 	capi_e2e "sigs.k8s.io/cluster-api/test/e2e"
 )
 
-var _ = Describe("[Management Upgrade] Running the Cluster API E2E tests", func() {
+var _ = Describe("[Management-Upgrade] Running the Cluster API E2E tests", func() {
 	ctx := context.TODO()
 
-	Context("[Needs Published Image] Running tests that require published images", func() {
+	Context("[Needs-Published-Image] Running tests that require published images", func() {
 		Context("Running the clusterctl upgrade spec on a cluster with packet-ccm", func() {
 			capi_e2e.ClusterctlUpgradeSpec(ctx, func() capi_e2e.ClusterctlUpgradeSpecInput {
 				return capi_e2e.ClusterctlUpgradeSpecInput{

--- a/test/e2e/capi_e2e_self_hosted_test.go
+++ b/test/e2e/capi_e2e_self_hosted_test.go
@@ -26,10 +26,10 @@ import (
 	capi_e2e "sigs.k8s.io/cluster-api/test/e2e"
 )
 
-var _ = Describe("[Self Hosted] Running the Cluster API E2E self-hosted tests", func() {
+var _ = Describe("[Self-Hosted] Running the Cluster API E2E self-hosted tests", func() {
 	ctx := context.TODO()
 
-	Context("[Needs Published Image] Running tests that require published images", func() {
+	Context("[Needs-Published-Image] Running tests that require published images", func() {
 		Context("Running the self-hosted spec", func() {
 			capi_e2e.SelfHostedSpec(ctx, func() capi_e2e.SelfHostedSpecInput {
 				return capi_e2e.SelfHostedSpecInput{

--- a/test/e2e/capi_e2e_workload_upgrade_test.go
+++ b/test/e2e/capi_e2e_workload_upgrade_test.go
@@ -28,7 +28,7 @@ import (
 	"sigs.k8s.io/cluster-api/test/framework/clusterctl"
 )
 
-var _ = Describe("[Workload Upgrade] Running the Cluster API E2E Workload Cluster Upgrade tests", func() {
+var _ = Describe("[Workload-Upgrade] Running the Cluster API E2E Workload Cluster Upgrade tests", func() {
 	ctx := context.TODO()
 
 	// The following upstream tests are not implemented because they are subsets of


### PR DESCRIPTION
Signed-off-by: Chris Privitere <23177737+cprivitere@users.noreply.github.com>

<!-- please add a icon to the title of this PR (see https://sigs.k8s.io/cluster-api/VERSIONING.md), and delete this line and similar ones -->
<!-- the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, minor or feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🏃 (:running:, other) -->

**What this PR does / why we need it**:
This is another attempt at resolving e2e test failures.
We make the ginkgo and directory config sections of the makefile more like upstream.
We define and override the default ginkgo test timeout of 1hr to be 6hr instead.
We rename ginkgo tests to use hyphens and have no spaces to be compatible with the new way focus and skip arguments are passed to ginkgo by upstream.
