### PR TITLE
Remove single quote from test names

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -192,27 +192,27 @@ run-e2e-tests: $(KUSTOMIZE) $(GINKGO) $(E2E_CONF_FILE) e2e-test-templates $(if $
 
 .PHONY: test-e2e-conformance
 test-e2e-conformance:
-	$(MAKE) run-e2e-tests GINKGO_FOCUS="'\[Conformance\]'"
+	$(MAKE) run-e2e-tests GINKGO_FOCUS="\[Conformance\]"
 
 .PHONY: test-e2e-management-upgrade
 test-e2e-management-upgrade:
-	$(MAKE) run-e2e-tests GINKGO_FOCUS="'\[Management-Upgrade\]'"
+	$(MAKE) run-e2e-tests GINKGO_FOCUS="\[Management-Upgrade\]"
 
 .PHONY: test-e2e-workload-upgrade
 test-e2e-workload-upgrade:
-	$(MAKE) run-e2e-tests GINKGO_FOCUS="'\[Workload-Upgrade\]'"
+	$(MAKE) run-e2e-tests GINKGO_FOCUS="\[Workload-Upgrade\]"
 
 .PHONY: test-e2e-quickstart
 test-e2e-quickstart:
-	$(MAKE) run-e2e-tests GINKGO_FOCUS="'\[QuickStart\]'"
+	$(MAKE) run-e2e-tests GINKGO_FOCUS="\[QuickStart\]"
 
 .PHONY: test-e2e-local
 test-e2e-local:
-	$(MAKE) run-e2e-tests GINKGO_SKIP="'\[QuickStart\]|\[Conformance\]|\[Needs-Published-Image\]|\[Management-Upgrade\]|\[Workload-Upgrade\]'"
+	$(MAKE) run-e2e-tests GINKGO_SKIP="\[QuickStart\]|\[Conformance\]|\[Needs-Published-Image\]|\[Management-Upgrade\]|\[Workload-Upgrade\]"
 
 .PHONY: test-e2e-ci
 test-e2e-ci:
-	$(MAKE) run-e2e-tests GINKGO_SKIP="'\[QuickStart\]|\[Conformance\]|\[Management-Upgrade\]|\[Workload-Upgrade\]'"
+	$(MAKE) run-e2e-tests GINKGO_SKIP="\[QuickStart\]|\[Conformance\]|\[Management-Upgrade\]|\[Workload-Upgrade\]"
 
 ## --------------------------------------
 ## E2E Test Templates


### PR DESCRIPTION
Signed-off-by: Chris Privitere <23177737+cprivitere@users.noreply.github.com>

<!-- please add a icon to the title of this PR (see https://sigs.k8s.io/cluster-api/VERSIONING.md), and delete this line and similar ones -->
<!-- the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, minor or feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🏃 (:running:, other) -->

**What this PR does / why we need it**: Due to the new quote style of the GINKGO_FOCUS and SKIP variables in the makefile, we need to not have single quotes in our GINGKO_FOCUS or GINKGO_SKIP definitions.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #
