### PR TITLE
:sparkle: add github token to ci workflows

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -190,6 +190,7 @@ jobs:
         TAG: ${{ steps.meta.outputs.version }}
     - name: "e2e-quickstart"
       env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         TAG: ${{ steps.meta.outputs.version }}
         PACKET_API_KEY: ${{ secrets.PACKET_API_TOKEN }}
         PROJECT_ID: ${{ secrets.PROJECT_ID }}
@@ -248,6 +249,7 @@ jobs:
         TAG: ${{ steps.meta.outputs.version }}
     - name: "e2e"
       env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         TAG: ${{ steps.meta.outputs.version }}
         PACKET_API_KEY: ${{ secrets.PACKET_API_TOKEN }}
         PROJECT_ID: ${{ secrets.PROJECT_ID }}
@@ -306,6 +308,7 @@ jobs:
         TAG: ${{ steps.meta.outputs.version }}
     - name: "e2e-conformance"
       env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         TAG: ${{ steps.meta.outputs.version }}
         PACKET_API_KEY: ${{ secrets.PACKET_API_TOKEN }}
         PROJECT_ID: ${{ secrets.PROJECT_ID }}
@@ -364,6 +367,7 @@ jobs:
         TAG: ${{ steps.meta.outputs.version }}
     - name: "e2e-management-upgrade"
       env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         TAG: ${{ steps.meta.outputs.version }}
         PACKET_API_KEY: ${{ secrets.PACKET_API_TOKEN }}
         PROJECT_ID: ${{ secrets.PROJECT_ID }}
@@ -422,6 +426,7 @@ jobs:
         TAG: ${{ steps.meta.outputs.version }}
     - name: "e2e-workload-upgrade"
       env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         TAG: ${{ steps.meta.outputs.version }}
         PACKET_API_KEY: ${{ secrets.PACKET_API_TOKEN }}
         PROJECT_ID: ${{ secrets.PROJECT_ID }}


### PR DESCRIPTION
Signed-off-by: Chris Privitere <23177737+cprivitere@users.noreply.github.com>

<!-- please add an icon to the title of this PR (see https://sigs.k8s.io/cluster-api/CONTRIBUTING.md#contributing-a-patch), and delete this line and similar ones -->
<!-- the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) -->

**What this PR does / why we need it**: This PR adds the GITHUB_TOKEN to the 5 E2E test runs to avoid api rate limiting from github caused by requests from the clusterctl client.go code.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
