### PR TITLE
:bug: fix e2e test setup code to use metro

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -168,7 +168,7 @@ endif
 # Additinal GINKGO overrides
 GINKGO_FLAKE_ATTEMPTS ?= 0
 E2E_CONF_FILE_SOURCE ?= $(ROOT_DIR)/$(TEST_DIR)/e2e/config/packet-ci.yaml
-SKIP_IMAGE_BUILD ?= false
+SKIP_IMAGE_BUILD ?= 
 
 ARTIFACTS ?= $(ROOT_DIR)/_artifacts
 

--- a/test/e2e/suite_test.go
+++ b/test/e2e/suite_test.go
@@ -110,7 +110,7 @@ var _ = SynchronizedBeforeSuite(func() []byte {
 	// Before all ParallelNodes.
 	Expect(os.Getenv(AuthTokenEnvVar)).NotTo(BeEmpty())
 	Expect(os.Getenv(ProjectIDEnvVar)).NotTo(BeEmpty())
-	Expect(os.Getenv("FACILITY")).NotTo(BeEmpty())
+	Expect(os.Getenv("METRO")).NotTo(BeEmpty())
 	Expect(os.Getenv("CONTROLPLANE_NODE_TYPE")).NotTo(BeEmpty())
 	Expect(os.Getenv("WORKER_NODE_TYPE")).NotTo(BeEmpty())
 


### PR DESCRIPTION
Signed-off-by: Chris Privitere <23177737+cprivitere@users.noreply.github.com>

<!-- please add an icon to the title of this PR (see https://sigs.k8s.io/cluster-api/CONTRIBUTING.md#contributing-a-patch), and delete this line and similar ones -->
<!-- the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) -->

**What this PR does / why we need it**:
This fixes the e2e test setup code to check for METRO instead of FACILITY. We switched all the tests to use METRO last week but forgot to update the validation code.
**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #