### PR TITLE
:bug: Move to 20.04 as default

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,8 +50,8 @@ You should then follow the [Cluster API Quick Start Guide](https://cluster-api.s
 If you do not change the generated `yaml` files, it will use defaults. You can look in the [templates/cluster-template.yaml](./templates/cluster-template.yaml) file for details.
 
 * `CPEM_VERSION`                 (defaults to `v3.6.0`)
-* `KUBE_VIP_VERSION`             (defaults to `v0.5.0`)
-* `NODE_OS`                      (defaults to `ubuntu_22_04`)
+* `KUBE_VIP_VERSION`             (defaults to `v0.5.12`)
+* `NODE_OS`                      (defaults to `ubuntu_20_04`)
 * `POD_CIDR`                     (defaults to `192.168.0.0/16`)
 * `SERVICE_CIDR`                 (defaults to `172.26.0.0/16`)
   
@@ -70,7 +70,7 @@ spec:
     spec:
       billingCycle: hourly
       machineType: c3.small.x86
-      os: ubuntu_22_04
+      os: ubuntu_20_04
       sshKeys:
       - ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIDvMgVEubPLztrvVKgNPnRe9sZSjAqaYj9nmCkgr4PdK username@computer
       tags: []

--- a/docs/concepts/machine.md
+++ b/docs/concepts/machine.md
@@ -11,7 +11,7 @@ kind: PacketMachine
 metadata:
   name: "qa-controlplane-0"
 spec:
-  os: "ubuntu_22_04"
+  os: "ubuntu_20_04"
   billingCycle: hourly
   machineType: "c3.small.x86"
   sshKeys:

--- a/templates/cluster-template-crs-cni.yaml
+++ b/templates/cluster-template-crs-cni.yaml
@@ -238,7 +238,7 @@ spec:
     spec:
       billingCycle: hourly
       machineType: ${CONTROLPLANE_NODE_TYPE}
-      os: ${NODE_OS:=ubuntu_22_04}
+      os: ${NODE_OS:=ubuntu_20_04}
       sshKeys:
       - ${SSH_KEY}
       tags: []
@@ -252,7 +252,7 @@ spec:
     spec:
       billingCycle: hourly
       machineType: ${WORKER_NODE_TYPE}
-      os: ${NODE_OS:=ubuntu_22_04}
+      os: ${NODE_OS:=ubuntu_20_04}
       sshKeys:
       - ${SSH_KEY}
       tags: []

--- a/templates/cluster-template-kube-vip-crs-cni.yaml
+++ b/templates/cluster-template-kube-vip-crs-cni.yaml
@@ -257,7 +257,7 @@ spec:
     spec:
       billingCycle: hourly
       machineType: ${CONTROLPLANE_NODE_TYPE}
-      os: ${NODE_OS:=ubuntu_22_04}
+      os: ${NODE_OS:=ubuntu_20_04}
       sshKeys:
       - ${SSH_KEY}
       tags: []
@@ -271,7 +271,7 @@ spec:
     spec:
       billingCycle: hourly
       machineType: ${WORKER_NODE_TYPE}
-      os: ${NODE_OS:=ubuntu_22_04}
+      os: ${NODE_OS:=ubuntu_20_04}
       sshKeys:
       - ${SSH_KEY}
       tags: []

--- a/templates/cluster-template-kube-vip.yaml
+++ b/templates/cluster-template-kube-vip.yaml
@@ -236,7 +236,7 @@ spec:
     spec:
       billingCycle: hourly
       machineType: ${CONTROLPLANE_NODE_TYPE}
-      os: ${NODE_OS:=ubuntu_22_04}
+      os: ${NODE_OS:=ubuntu_20_04}
       sshKeys:
       - ${SSH_KEY}
       tags: []
@@ -250,7 +250,7 @@ spec:
     spec:
       billingCycle: hourly
       machineType: ${WORKER_NODE_TYPE}
-      os: ${NODE_OS:=ubuntu_22_04}
+      os: ${NODE_OS:=ubuntu_20_04}
       sshKeys:
       - ${SSH_KEY}
       tags: []

--- a/templates/cluster-template.yaml
+++ b/templates/cluster-template.yaml
@@ -102,7 +102,7 @@ metadata:
 spec:
   template:
     spec:
-      os: "${NODE_OS:=ubuntu_22_04}"
+      os: "${NODE_OS:=ubuntu_20_04}"
       billingCycle: hourly
       machineType: "${CONTROLPLANE_NODE_TYPE}"
       sshKeys:
@@ -178,7 +178,7 @@ metadata:
 spec:
   template:
     spec:
-      os: "${NODE_OS:=ubuntu_22_04}"
+      os: "${NODE_OS:=ubuntu_20_04}"
       billingCycle: hourly
       machineType: "${WORKER_NODE_TYPE}"
       sshKeys:

--- a/test/e2e/config/packet-ci-actions.yaml
+++ b/test/e2e/config/packet-ci-actions.yaml
@@ -147,7 +147,7 @@ variables:
   COREDNS_VERSION_UPGRADE_TO: "v1.9.3"
 
   # Infra provider specific variables
-  NODE_OS: "ubuntu_22_04"
+  NODE_OS: "ubuntu_20_04"
   POD_CIDR: "192.168.0.0/16"
   SERVICE_CIDR: "172.26.0.0/16"
 

--- a/test/e2e/config/packet-ci.yaml
+++ b/test/e2e/config/packet-ci.yaml
@@ -152,7 +152,7 @@ variables:
   COREDNS_VERSION_UPGRADE_TO: "v1.9.3"
 
   # Infra provider specific variables
-  NODE_OS: "ubuntu_22_04"
+  NODE_OS: "ubuntu_20_04"
   POD_CIDR: "192.168.0.0/16"
   SERVICE_CIDR: "172.26.0.0/16"
 

--- a/test/e2e/data/v1alpha3/bases/cluster-with-kcp-cpem.yaml
+++ b/test/e2e/data/v1alpha3/bases/cluster-with-kcp-cpem.yaml
@@ -43,7 +43,7 @@ metadata:
 spec:
   template:
     spec:
-      OS: "${NODE_OS:=ubuntu_22_04}"
+      OS: "${NODE_OS:=ubuntu_20_04}"
       billingCycle: hourly
       machineType: "${CONTROLPLANE_NODE_TYPE}"
       sshKeys:

--- a/test/e2e/data/v1alpha3/bases/cluster-with-kcp-packet-ccm.yaml
+++ b/test/e2e/data/v1alpha3/bases/cluster-with-kcp-packet-ccm.yaml
@@ -43,7 +43,7 @@ metadata:
 spec:
   template:
     spec:
-      OS: "${NODE_OS:=ubuntu_22_04}"
+      OS: "${NODE_OS:=ubuntu_20_04}"
       billingCycle: hourly
       machineType: "${CONTROLPLANE_NODE_TYPE}"
       sshKeys:

--- a/test/e2e/data/v1alpha3/bases/md.yaml
+++ b/test/e2e/data/v1alpha3/bases/md.yaml
@@ -7,7 +7,7 @@ metadata:
 spec:
   template:
     spec:
-      OS: "${NODE_OS:=ubuntu_22_04}"
+      OS: "${NODE_OS:=ubuntu_20_04}"
       billingCycle: hourly
       machineType: "${WORKER_NODE_TYPE}"
       sshKeys:


### PR DESCRIPTION
<!-- please add an icon to the title of this PR (see https://sigs.k8s.io/cluster-api/CONTRIBUTING.md#contributing-a-patch), and delete this line and similar ones -->
<!-- the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) -->

**What this PR does / why we need it**:
- Set our default OS to Ubuntu 20.04 due to bugs in the Ubuntu 22.04 image with DNS.