### PR TITLE
:sparkles: Refactor release ci and go back to using quay as default 

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -14,8 +14,7 @@ env:
   GHCR_REGISTRY: ghcr.io/${{ github.repository_owner }}
   DOCKER_REGISTRY: ${{ secrets.DOCKER_ORG }}
   QUAY_REGISTRY: quay.io/${{ secrets.QUAY_ORG }}
-  REGISTRY: ghcr.io/${{ github.repository_owner }}
-
+  REGISTRY: ${{ env.QUAY_REGISTRY }}
 
 jobs:
   validate:
@@ -91,7 +90,10 @@ jobs:
       id: docker_meta
       uses: docker/metadata-action@v4
       with:
-        images: ${{ env.GHCR_REGISTRY }}/${{ env.IMAGE_NAME }}
+        images: |
+          ${{ env.QUAY_REGISTRY }}/${{ env.IMAGE_NAME }}
+          ${{ env.GHCR_REGISTRY }}/${{ env.IMAGE_NAME }}
+          ${{ env.DOCKER_REGISTRY }}/${{ env.IMAGE_NAME }}
         flavor: |
           latest=false
         tags: |
@@ -103,7 +105,7 @@ jobs:
             type=ref,event=pr
             type=sha,priority=1001
 
-    - name: Docker Build and Push to GHCR
+    - name: Docker Build and Push
       uses: docker/build-push-action@v4
       with:
         context: .
@@ -196,7 +198,7 @@ jobs:
         path: out/release
 
     - name: Prepull the pre-built image
-      run: docker pull ${GHCR_REGISTRY}/${IMAGE_NAME}:${TAG}
+      run: docker pull ${REGISTRY}/${IMAGE_NAME}:${TAG}
 
     - name: "e2e-quickstart"
       env:
@@ -243,7 +245,7 @@ jobs:
         path: out/release
 
     - name: Prepull the pre-built image
-      run: docker pull ${GHCR_REGISTRY}/${IMAGE_NAME}:${TAG}
+      run: docker pull ${REGISTRY}/${IMAGE_NAME}:${TAG}
 
     - name: "e2e"
       env:
@@ -290,7 +292,7 @@ jobs:
         path: out/release
 
     - name: Prepull the pre-built image
-      run: docker pull ${GHCR_REGISTRY}/${IMAGE_NAME}:${TAG}
+      run: docker pull ${REGISTRY}/${IMAGE_NAME}:${TAG}
 
     - name: "e2e-conformance"
       env:
@@ -337,7 +339,7 @@ jobs:
         path: out/release
 
     - name: Prepull the pre-built image
-      run: docker pull ${GHCR_REGISTRY}/${IMAGE_NAME}:${TAG}
+      run: docker pull ${REGISTRY}/${IMAGE_NAME}:${TAG}
 
     - name: "e2e-management-upgrade"
       env:
@@ -385,7 +387,7 @@ jobs:
         path: out/release
 
     - name: Prepull the pre-built image
-      run: docker pull ${GHCR_REGISTRY}/${IMAGE_NAME}:${TAG}
+      run: docker pull ${REGISTRY}/${IMAGE_NAME}:${TAG}
 
     - name: "e2e-workload-upgrade"
       env:

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -9,36 +9,29 @@ env:
   GHCR_REGISTRY: ghcr.io/${{ github.repository_owner }}
   DOCKER_REGISTRY: ${{ secrets.DOCKER_ORG }}
   QUAY_REGISTRY: quay.io/${{ secrets.QUAY_ORG }}
-  REGISTRY: quay.io/${{ secrets.QUAY_ORG }}
-  metadata_flavor: latest=false
-  metadata_tags: type=ref,event=tag
+  REGISTRY: ${{ env.QUAY_REGISTRY }}
+
 jobs:
-  manager-image:
-    name: Build and push manager image
+
+  build-image:
+    name: Build and Push Image
     runs-on: ubuntu-latest
+
+    permissions:
+      packages: write # needed to push docker image to ghcr.io
+
     steps:
-    - name: Checkout code
+
+    - name: Checkout git repo
       uses: actions/checkout@v3
-      with:
-        fetch-depth: 0
-    - uses: actions/setup-go@v4
-      with: 
-        go-version-file: './go.mod'
+
     - name: Set up QEMU
       uses: docker/setup-qemu-action@v2
+
     - name: Set up Docker Buildx
       uses: docker/setup-buildx-action@v2
 
-    - name: Generate metadata
-      id: meta
-      uses: ./.github/actions/metadata
-      with:
-        docker_username: ${{ secrets.DOCKER_USERNAME }}
-        quay_username: ${{ secrets.QUAY_USERNAME }}
-        metadata_flavor: ${{ env.metadata_flavor }}
-        metadata_tags: ${{ env.metadata_tags }}
-
-    - name: Log in to ghcr.io
+    - name: Login to ghcr.io registry
       uses: docker/login-action@v2
       with:
         registry: ghcr.io
@@ -64,6 +57,23 @@ jobs:
         username: ${{ secrets.QUAY_USERNAME }}
         password: ${{ secrets.QUAY_PASSWORD }}
 
+    - name: Docker meta
+      id: docker_meta
+      uses: docker/metadata-action@v4
+      with:
+        images: |
+          ${{ env.QUAY_REGISTRY }}/${{ env.IMAGE_NAME }}
+          ${{ env.GHCR_REGISTRY }}/${{ env.IMAGE_NAME }}
+          ${{ env.DOCKER_REGISTRY }}/${{ env.IMAGE_NAME }}
+        flavor: |
+          latest=auto
+        tags: |
+            type=semver,pattern={{version}}
+            type=ref,event=branch
+            type=ref,event=tag
+            type=ref,event=pr
+            type=sha
+
     - name: Setup Env
       run: |
         DOCKER_BUILD_LDFLAGS="$(hack/version.sh)"
@@ -71,51 +81,40 @@ jobs:
         echo $DOCKER_BUILD_LDFLAGS >> $GITHUB_ENV
         echo 'EOF' >> $GITHUB_ENV
 
-    - name: Build and push manager image
+    - name: Docker Build and Push
       uses: docker/build-push-action@v4
       with:
         context: .
         push: true
         build-args: |
           LDFLAGS=${{ env.DOCKER_BUILD_LDFLAGS }}
-        tags: ${{ steps.meta.outputs.tags }}
-        labels: ${{ steps.meta.outputs.labels }}
-        platforms: linux/amd64,linux/arm64
-        cache-from: type=gha, scope=${{ github.workflow }}
-        cache-to: type=gha, mode=max, scope=${{ github.workflow }}
+        tags: ${{ steps.docker_meta.outputs.tags }}
+        labels: ${{ steps.docker_meta.outpus.labels }}
+        cache-from: type=gha
+        cache-to: type=gha,mode=max
+        platforms: linux/amd64, linux/arm64, linux/arm/v7
+
+    outputs:
+      image-tag: "${{ steps.docker_meta.outputs.version }}"
 
   release:
-    name: Release
+    name: Create Release
     runs-on: ubuntu-latest
-    needs:
-    - manager-image
+    needs: [build-image]
+    env:
+      TAG: ${{ needs.build-image.outputs.image-tag }}
+
     steps:
-    - name: Checkout code
+    
+    - name: checkout
       uses: actions/checkout@v3
+    
     - uses: actions/setup-go@v4
       with: 
         go-version-file: './go.mod'
-    - uses: actions/cache@v3
-      with:
-        path: hack/tools/bin
-        key: ${{ runner.os }}-tools-bin-release-${{ hashFiles('Makefile') }}
-        restore-keys: |
-          ${{ runner.os }}-tools-bin-release-
-          ${{ runner.os }}-tools-bin-
-   
-    - name: Generate metadata
-      id: meta
-      uses: ./.github/actions/metadata
-      with:
-        docker_username: ${{ secrets.DOCKER_USERNAME }}
-        quay_username: ${{ secrets.QUAY_USERNAME }}
-        metadata_flavor: ${{ env.metadata_flavor }}
-        metadata_tags: ${{ env.metadata_tags }}
 
-    - name: manifest
+    - name: Make Release
       run: make release
-      env:
-        TAG: ${{ steps.meta.outputs.version }}
 
     - name: Generate Release Notes
       run: |
@@ -127,6 +126,7 @@ jobs:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         OWNER: ${{ github.repository_owner }}
         REPO: ${{ github.event.repository.name }}
+
     - name: Create Release
       uses: softprops/action-gh-release@v1
       if: startsWith(github.ref, 'refs/tags/')

--- a/test/e2e/config/packet-ci-actions.yaml
+++ b/test/e2e/config/packet-ci-actions.yaml
@@ -6,7 +6,7 @@
 # - packet
 
 images:
-- name: "${REGISTRY:=ghcr.io/kubernetes-sigs}/${IMAGE_NAME:=cluster-api-provider-packet}:${TAG:=e2e}"
+- name: "${REGISTRY:=quay.io/kubernetes-sigs}/${IMAGE_NAME:=cluster-api-provider-packet}:${TAG:=e2e}"
   loadBehavior: mustLoad
 
 providers:

--- a/test/e2e/config/packet-ci.yaml
+++ b/test/e2e/config/packet-ci.yaml
@@ -6,7 +6,7 @@
 # - packet
 
 images:
-- name: "${REGISTRY:=ghcr.io/kubernetes-sigs}/${IMAGE_NAME:=cluster-api-provider-packet}:${TAG:=e2e}"
+- name: "${REGISTRY:=quay.io/kubernetes-sigs}/${IMAGE_NAME:=cluster-api-provider-packet}:${TAG:=e2e}"
   loadBehavior: mustLoad
 
 providers:


### PR DESCRIPTION
<!-- please add an icon to the title of this PR (see https://sigs.k8s.io/cluster-api/CONTRIBUTING.md#contributing-a-patch), and delete this line and similar ones -->
<!-- the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) -->

**What this PR does / why we need it**:
- Go back to quay as default as ghcr isn't publicly accessible on this repo
- re-add quay and docker to the metadata generation, this was an oversight on the earlier CI refactor
- Refactor the release ci yaml like we did to the main ci yaml
  - remove caching
  - Add tags to like we have in main ci
  - Publish for arm/v7
  - remove custom metadata action
