### PR TITLE
✨Modify type.go to include shortNames for few Packet CRDs

### DIFF
--- a/api/v1alpha3/packetcluster_types.go
+++ b/api/v1alpha3/packetcluster_types.go
@@ -56,7 +56,7 @@ type PacketClusterStatus struct {
 }
 
 // +kubebuilder:subresource:status
-// +kubebuilder:resource:path=packetclusters,scope=Namespaced,categories=cluster-api
+// +kubebuilder:resource:path=packetclusters,shortName=pcl,scope=Namespaced,categories=cluster-api
 // +kubebuilder:object:root=true
 // +kubebuilder:printcolumn:name="Cluster",type="string",JSONPath=".metadata.labels.cluster\\.x-k8s\\.io/cluster-name",description="Cluster to which this PacketCluster belongs"
 // +kubebuilder:printcolumn:name="Ready",type="string",JSONPath=".status.ready",description="PacketCluster ready status"

--- a/api/v1alpha3/packetmachine_types.go
+++ b/api/v1alpha3/packetmachine_types.go
@@ -105,7 +105,7 @@ type PacketMachineStatus struct {
 
 // +kubebuilder:subresource:status
 // +kubebuilder:object:root=true
-// +kubebuilder:resource:path=packetmachines,scope=Namespaced,categories=cluster-api
+// +kubebuilder:resource:path=packetmachines,shortName=pma,scope=Namespaced,categories=cluster-api
 // +kubebuilder:printcolumn:name="Cluster",type="string",JSONPath=".metadata.labels.cluster\\.x-k8s\\.io/cluster-name",description="Cluster to which this PacketMachine belongs"
 // +kubebuilder:printcolumn:name="State",type="string",JSONPath=".status.instanceState",description="Packet instance state"
 // +kubebuilder:printcolumn:name="Ready",type="string",JSONPath=".status.ready",description="Machine ready status"

--- a/api/v1alpha3/packetmachinetemplate_types.go
+++ b/api/v1alpha3/packetmachinetemplate_types.go
@@ -26,7 +26,7 @@ type PacketMachineTemplateSpec struct {
 }
 
 // +kubebuilder:object:root=true
-// +kubebuilder:resource:path=packetmachinetemplates,scope=Namespaced,categories=cluster-api
+// +kubebuilder:resource:path=packetmachinetemplates,shortName=pmt,scope=Namespaced,categories=cluster-api
 
 // PacketMachineTemplate is the Schema for the packetmachinetemplates API
 type PacketMachineTemplate struct {

--- a/api/v1beta1/packetcluster_types.go
+++ b/api/v1beta1/packetcluster_types.go
@@ -65,7 +65,7 @@ type PacketClusterStatus struct {
 }
 
 // +kubebuilder:subresource:status
-// +kubebuilder:resource:path=packetclusters,scope=Namespaced,categories=cluster-api
+// +kubebuilder:resource:path=packetclusters,shortName=pcl,scope=Namespaced,categories=cluster-api
 // +kubebuilder:object:root=true
 // +kubebuilder:storageversion
 // +kubebuilder:printcolumn:name="Cluster",type="string",JSONPath=".metadata.labels.cluster\\.x-k8s\\.io/cluster-name",description="Cluster to which this PacketCluster belongs"

--- a/api/v1beta1/packetmachine_types.go
+++ b/api/v1beta1/packetmachine_types.go
@@ -132,7 +132,7 @@ type PacketMachineStatus struct {
 
 // +kubebuilder:subresource:status
 // +kubebuilder:object:root=true
-// +kubebuilder:resource:path=packetmachines,scope=Namespaced,categories=cluster-api
+// +kubebuilder:resource:path=packetmachines,shortName=pma,scope=Namespaced,categories=cluster-api
 // +kubebuilder:storageversion
 // +kubebuilder:printcolumn:name="Cluster",type="string",JSONPath=".metadata.labels.cluster\\.x-k8s\\.io/cluster-name",description="Cluster to which this PacketMachine belongs"
 // +kubebuilder:printcolumn:name="State",type="string",JSONPath=".status.instanceState",description="Packet instance state"

--- a/api/v1beta1/packetmachinetemplate_types.go
+++ b/api/v1beta1/packetmachinetemplate_types.go
@@ -26,7 +26,7 @@ type PacketMachineTemplateSpec struct {
 }
 
 // +kubebuilder:object:root=true
-// +kubebuilder:resource:path=packetmachinetemplates,scope=Namespaced,categories=cluster-api
+// +kubebuilder:resource:path=packetmachinetemplates,shortName=pmt,scope=Namespaced,categories=cluster-api
 // +kubebuilder:storageversion
 
 // PacketMachineTemplate is the Schema for the packetmachinetemplates API

--- a/config/crd/bases/infrastructure.cluster.x-k8s.io_packetclusters.yaml
+++ b/config/crd/bases/infrastructure.cluster.x-k8s.io_packetclusters.yaml
@@ -14,6 +14,8 @@ spec:
     kind: PacketCluster
     listKind: PacketClusterList
     plural: packetclusters
+    shortNames:
+    - pcl
     singular: packetcluster
   scope: Namespaced
   versions:

--- a/config/crd/bases/infrastructure.cluster.x-k8s.io_packetmachines.yaml
+++ b/config/crd/bases/infrastructure.cluster.x-k8s.io_packetmachines.yaml
@@ -14,6 +14,8 @@ spec:
     kind: PacketMachine
     listKind: PacketMachineList
     plural: packetmachines
+    shortNames:
+    - pma
     singular: packetmachine
   scope: Namespaced
   versions:

--- a/config/crd/bases/infrastructure.cluster.x-k8s.io_packetmachinetemplates.yaml
+++ b/config/crd/bases/infrastructure.cluster.x-k8s.io_packetmachinetemplates.yaml
@@ -14,6 +14,8 @@ spec:
     kind: PacketMachineTemplate
     listKind: PacketMachineTemplateList
     plural: packetmachinetemplates
+    shortNames:
+    - pmt
     singular: packetmachinetemplate
   scope: Namespaced
   versions:


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR adds shortNames to several packet CRDs.

**Which issue(s) this PR fixes**:
Fixes #421. 

Local Run:

```
# kubectl api-resources | grep -i packet
NAME                              SHORTNAMES   APIVERSION                                NAMESPACED   KIND
packetclusters                    pcl          infrastructure.cluster.x-k8s.io/v1beta1   true         PacketCluster
packetmachines                    pma          infrastructure.cluster.x-k8s.io/v1beta1   true         PacketMachine
packetmachinetemplates            pmt          infrastructure.cluster.x-k8s.io/v1beta1   true         PacketMachineTemplate
```