### PR TITLE
:sparkles: Update CI workflow for PR auto updates with image tags

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -116,36 +116,6 @@ jobs:
         cache-to: type=gha,mode=max
         platforms: linux/amd64, linux/arm64, linux/arm/v7
 
-      # If PR, put image tags in the PR comments
-      # from https://github.com/marketplace/actions/create-or-update-comment
-    - name: Find comment for image tags
-      uses: peter-evans/find-comment@v2
-      if: github.event_name == 'pull_request'
-      id: fc
-      with:
-        issue-number: ${{ github.event.pull_request.number }}
-        comment-author: 'github-actions[bot]'
-        body-includes: Docker image tag(s) pushed
-
-      # If PR, put image tags in the PR comments
-    - name: Create or update comment for image tags
-      uses: peter-evans/create-or-update-comment@v3
-      if: github.event_name == 'pull_request'
-      with:
-        comment-id: ${{ steps.fc.outputs.comment-id }}
-        issue-number: ${{ github.event.pull_request.number }}
-        body: |
-          Docker image tag(s) pushed:
-          ```text
-          ${{ steps.docker_meta.outputs.tags }}
-          ```
-
-          Labels added to images:
-          ```text
-          ${{ steps.docker_meta.outputs.labels }}
-          ```
-        edit-mode: replace
-
     outputs:
       image-tag: "${{ steps.docker_meta.outputs.version }}"
 

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -61,6 +61,25 @@ jobs:
         username: ${{ github.actor }}
         password: ${{ secrets.GITHUB_TOKEN }}
 
+    - name: Log into DockerHub
+      uses: docker/login-action@v2
+      env:
+        DOCKER_USERNAME: ${{ secrets.DOCKER_USERNAME }}
+      if: ${{ env.DOCKER_USERNAME != '' }}
+      with:
+        username: ${{ secrets.DOCKER_USERNAME }}
+        password: ${{ secrets.DOCKER_PASSWORD }}
+
+    - name: Log into quay.io
+      uses: docker/login-action@v2
+      env:
+        QUAY_USERNAME: ${{ secrets.QUAY_USERNAME }}
+      if: ${{ env.QUAY_USERNAME != '' }}
+      with:
+        registry: quay.io
+        username: ${{ secrets.QUAY_USERNAME }}
+        password: ${{ secrets.QUAY_PASSWORD }}
+
     - name: Docker meta
       id: docker_meta
       uses: docker/metadata-action@v4

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -30,3 +30,111 @@ jobs:
 
     - name: ${{ matrix.target }}
       run: make ${{ matrix.target }}
+
+  build-image:
+    name: Build and Push Image
+    runs-on: ubuntu-latest
+
+    permissions:
+      packages: write # needed to push docker image to ghcr.io
+      pull-requests: write # needed to create and update comments in PRs
+
+
+    steps:
+
+    - name: Checkout git repo
+      uses: actions/checkout@v3
+
+    - name: Set up QEMU
+      uses: docker/setup-qemu-action@v2
+
+    - name: Set up Docker Buildx
+      uses: docker/setup-buildx-action@v2
+
+    - name: Login to ghcr.io registry
+      uses: docker/login-action@v2
+      with:
+        registry: ghcr.io
+        username: ${{ github.actor }}
+        password: ${{ secrets.GITHUB_TOKEN }}
+
+    - name: Log into DockerHub
+      uses: docker/login-action@v2
+      env:
+        DOCKER_USERNAME: ${{ secrets.DOCKER_USERNAME }}
+      if: ${{ env.DOCKER_USERNAME != '' }}
+      with:
+        username: ${{ secrets.DOCKER_USERNAME }}
+        password: ${{ secrets.DOCKER_PASSWORD }}
+
+    - name: Log into quay.io
+      uses: docker/login-action@v2
+      env:
+        QUAY_USERNAME: ${{ secrets.QUAY_USERNAME }}
+      if: ${{ env.QUAY_USERNAME != '' }}
+      with:
+        registry: quay.io
+        username: ${{ secrets.QUAY_USERNAME }}
+        password: ${{ secrets.QUAY_PASSWORD }}
+
+    - name: Docker meta
+      id: docker_meta
+      uses: docker/metadata-action@v4
+      with:
+        images: |
+          ${{ env.QUAY_REGISTRY }}/${{ env.IMAGE_NAME }}
+          ${{ env.GHCR_REGISTRY }}/${{ env.IMAGE_NAME }}
+          ${{ env.DOCKER_REGISTRY }}/${{ env.IMAGE_NAME }}
+        flavor: |
+          latest=false
+        tags: |
+            type=semver,pattern={{version}}
+            type=edge
+            type=ref,event=branch
+            type=ref,event=tag
+            type=ref,event=pr
+            type=sha,priority=1001
+
+    - name: Docker Build and Push
+      uses: docker/build-push-action@v4
+      with:
+        context: .
+        push: true
+        tags: ${{ steps.docker_meta.outputs.tags }}
+        labels: ${{ steps.docker_meta.outputs.labels }}
+        cache-from: type=gha
+        cache-to: type=gha,mode=max
+        platforms: linux/amd64, linux/arm64, linux/arm/v7
+
+      # If PR, put image tags in the PR comments
+      # from https://github.com/marketplace/actions/create-or-update-comment
+    - name: Find comment for image tags
+      uses: peter-evans/find-comment@v2
+      if: github.event_name == 'pull_request'
+      id: fc
+      with:
+        issue-number: ${{ github.event.pull_request.number }}
+        comment-author: 'github-actions[bot]'
+        body-includes: Docker image tag(s) pushed
+
+      # If PR, put image tags in the PR comments
+    - name: Create or update comment for image tags
+      uses: peter-evans/create-or-update-comment@v3
+      if: github.event_name == 'pull_request'
+      with:
+        comment-id: ${{ steps.fc.outputs.comment-id }}
+        issue-number: ${{ github.event.pull_request.number }}
+        body: |
+          Docker image tag(s) pushed:
+          ```text
+          ${{ steps.docker_meta.outputs.tags }}
+          ```
+
+          Labels added to images:
+          ```text
+          ${{ steps.docker_meta.outputs.labels }}
+          ```
+        edit-mode: replace
+
+    outputs:
+      image-tag: "${{ steps.docker_meta.outputs.version }}"

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -7,8 +7,6 @@ on:
 env:
   IMAGE_NAME: cluster-api-provider-packet
   GHCR_REGISTRY: ghcr.io/${{ github.repository_owner }}
-  DOCKER_REGISTRY: ${{ secrets.DOCKER_ORG }}
-  QUAY_REGISTRY: quay.io/${{ secrets.QUAY_ORG }}
   GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
 jobs:
@@ -61,33 +59,12 @@ jobs:
         username: ${{ github.actor }}
         password: ${{ secrets.GITHUB_TOKEN }}
 
-    - name: Log into DockerHub
-      uses: docker/login-action@v2
-      env:
-        DOCKER_USERNAME: ${{ secrets.DOCKER_USERNAME }}
-      if: ${{ env.DOCKER_USERNAME != '' }}
-      with:
-        username: ${{ secrets.DOCKER_USERNAME }}
-        password: ${{ secrets.DOCKER_PASSWORD }}
-
-    - name: Log into quay.io
-      uses: docker/login-action@v2
-      env:
-        QUAY_USERNAME: ${{ secrets.QUAY_USERNAME }}
-      if: ${{ env.QUAY_USERNAME != '' }}
-      with:
-        registry: quay.io
-        username: ${{ secrets.QUAY_USERNAME }}
-        password: ${{ secrets.QUAY_PASSWORD }}
-
     - name: Docker meta
       id: docker_meta
       uses: docker/metadata-action@v4
       with:
         images: |
-          ${{ env.QUAY_REGISTRY }}/${{ env.IMAGE_NAME }}
           ${{ env.GHCR_REGISTRY }}/${{ env.IMAGE_NAME }}
-          ${{ env.DOCKER_REGISTRY }}/${{ env.IMAGE_NAME }}
         flavor: |
           latest=false
         tags: |

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -5,8 +5,11 @@ on:
   workflow_dispatch:
 
 env:
+  IMAGE_NAME: cluster-api-provider-packet
+  GHCR_REGISTRY: ghcr.io/${{ github.repository_owner }}
+  DOCKER_REGISTRY: ${{ secrets.DOCKER_ORG }}
+  QUAY_REGISTRY: quay.io/${{ secrets.QUAY_ORG }}
   GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-
 
 jobs:
   validate:

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -62,6 +62,8 @@ jobs:
     - name: Docker meta
       id: docker_meta
       uses: docker/metadata-action@v4
+      env:
+        DOCKER_METADATA_PR_HEAD_SHA: true
       with:
         images: |
           ${{ env.GHCR_REGISTRY }}/${{ env.IMAGE_NAME }}

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -87,7 +87,9 @@ jobs:
         DOCKER_METADATA_PR_HEAD_SHA: true
       with:
         images: |
+          ${{ env.QUAY_REGISTRY }}/${{ env.IMAGE_NAME }}
           ${{ env.GHCR_REGISTRY }}/${{ env.IMAGE_NAME }}
+          ${{ env.DOCKER_REGISTRY }}/${{ env.IMAGE_NAME }}
         flavor: |
           latest=false
         tags: |

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -7,6 +7,8 @@ on:
 env:
   IMAGE_NAME: cluster-api-provider-packet
   GHCR_REGISTRY: ghcr.io/${{ github.repository_owner }}
+  DOCKER_REGISTRY: ${{ secrets.DOCKER_ORG }}
+  QUAY_REGISTRY: quay.io/${{ secrets.QUAY_ORG }}
   GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
 jobs:


### PR DESCRIPTION
<!-- please add an icon to the title of this PR (see https://sigs.k8s.io/cluster-api/CONTRIBUTING.md#contributing-a-patch), and delete this line and similar ones -->
<!-- the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) -->

**What this PR does / why we need it**: This PR fixes part of the ci workflow refactor that was supposed to enable auto updates of PRs with links to built images. This code was originally put in the wrong ci file (ci.yaml). This patch puts it into the correct file (pr.yaml), consequently, it adds image building to the pr workflow. This may need to be adjusted to only be amd64 images in the future, as image building seems to take a while at times.
