### PR TITLE
:bug: use quay.io for default registry

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -103,6 +103,7 @@ jobs:
     needs: [build-image]
     env:
       TAG: ${{ needs.build-image.outputs.image-tag }}
+      REGISTRY: ${{ env.QUAY_REGISTRY }}
 
     steps:
     


### PR DESCRIPTION
<!-- please add an icon to the title of this PR (see https://sigs.k8s.io/cluster-api/CONTRIBUTING.md#contributing-a-patch), and delete this line and similar ones -->
<!-- the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) -->

**What this PR does / why we need it**: The 0.7.0 release used ghcr.io as the default registry to publish to. However that registry is currently not public. This patch to the release workflow uses quay.io as the default registry. A (separate PR)[https://github.com/kubernetes/org/issues/4189] has been made to kubernetes-sigs to make the ghcr.io registry public.