### PR TITLE
Fix REGISTRY CI variable in release.yaml

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -103,7 +103,7 @@ jobs:
     needs: [build-image]
     env:
       TAG: ${{ needs.build-image.outputs.image-tag }}
-      REGISTRY: ${{ env.QUAY_REGISTRY }}
+      REGISTRY: quay.io/${{ secrets.QUAY_ORG }}
 
     steps:
     


### PR DESCRIPTION
<!-- please add an icon to the title of this PR (see https://sigs.k8s.io/cluster-api/CONTRIBUTING.md#contributing-a-patch), and delete this line and similar ones -->
<!-- the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) -->

**What this PR does / why we need it**: This fixes the REGISTRY env variable in the release.yaml. The last change was invalid as you can't reference previous env variables inside of the env: section.