### PR TITLE
:seedling: bump metal-go to v0.25.0

### DIFF
--- a/api/v1alpha3/packetmachine_types.go
+++ b/api/v1alpha3/packetmachine_types.go
@@ -32,7 +32,7 @@ const (
 // PacketMachineSpec defines the desired state of PacketMachine.
 type PacketMachineSpec struct {
 	OS           string                              `json:"OS"` //nolint: tagliatelle
-	BillingCycle metal.DeviceCreateInputBillingCycle `json:"billingCycle"`
+	BillingCycle metal.DeviceCreateInputBillingCycle `json:"billingCycle,omitempty"`
 	MachineType  string                              `json:"machineType"`
 	SshKeys      []string                            `json:"sshKeys,omitempty"`
 

--- a/api/v1alpha3/packetmachine_types.go
+++ b/api/v1alpha3/packetmachine_types.go
@@ -17,6 +17,7 @@ limitations under the License.
 package v1alpha3
 
 import (
+	metal "github.com/equinix-labs/metal-go/metal/v1"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	capierrors "sigs.k8s.io/cluster-api/errors"
@@ -30,10 +31,10 @@ const (
 
 // PacketMachineSpec defines the desired state of PacketMachine.
 type PacketMachineSpec struct {
-	OS           string   `json:"OS"` //nolint: tagliatelle
-	BillingCycle string   `json:"billingCycle"`
-	MachineType  string   `json:"machineType"`
-	SshKeys      []string `json:"sshKeys,omitempty"`
+	OS           string                              `json:"OS"` //nolint: tagliatelle
+	BillingCycle metal.DeviceCreateInputBillingCycle `json:"billingCycle"`
+	MachineType  string                              `json:"machineType"`
+	SshKeys      []string                            `json:"sshKeys,omitempty"`
 
 	// Facility represents the Packet facility for this cluster.
 	// Override from the PacketCluster spec.

--- a/api/v1alpha3/zz_generated.conversion.go
+++ b/api/v1alpha3/zz_generated.conversion.go
@@ -24,7 +24,8 @@ package v1alpha3
 import (
 	unsafe "unsafe"
 
-	v1 "k8s.io/api/core/v1"
+	v1 "github.com/equinix-labs/metal-go/metal/v1"
+	corev1 "k8s.io/api/core/v1"
 	conversion "k8s.io/apimachinery/pkg/conversion"
 	runtime "k8s.io/apimachinery/pkg/runtime"
 	v1beta1 "sigs.k8s.io/cluster-api-provider-packet/api/v1beta1"
@@ -359,7 +360,7 @@ func Convert_v1beta1_PacketMachineList_To_v1alpha3_PacketMachineList(in *v1beta1
 
 func autoConvert_v1alpha3_PacketMachineSpec_To_v1beta1_PacketMachineSpec(in *PacketMachineSpec, out *v1beta1.PacketMachineSpec, s conversion.Scope) error {
 	out.OS = in.OS
-	out.BillingCycle = in.BillingCycle
+	out.BillingCycle = v1.DeviceCreateInputBillingCycle(in.BillingCycle)
 	out.MachineType = in.MachineType
 	// WARNING: in.SshKeys requires manual conversion: does not exist in peer-type
 	out.Facility = in.Facility
@@ -373,7 +374,7 @@ func autoConvert_v1alpha3_PacketMachineSpec_To_v1beta1_PacketMachineSpec(in *Pac
 
 func autoConvert_v1beta1_PacketMachineSpec_To_v1alpha3_PacketMachineSpec(in *v1beta1.PacketMachineSpec, out *PacketMachineSpec, s conversion.Scope) error {
 	out.OS = in.OS
-	out.BillingCycle = in.BillingCycle
+	out.BillingCycle = v1.DeviceCreateInputBillingCycle(in.BillingCycle)
 	out.MachineType = in.MachineType
 	// WARNING: in.SSHKeys requires manual conversion: does not exist in peer-type
 	out.Facility = in.Facility
@@ -387,7 +388,7 @@ func autoConvert_v1beta1_PacketMachineSpec_To_v1alpha3_PacketMachineSpec(in *v1b
 
 func autoConvert_v1alpha3_PacketMachineStatus_To_v1beta1_PacketMachineStatus(in *PacketMachineStatus, out *v1beta1.PacketMachineStatus, s conversion.Scope) error {
 	out.Ready = in.Ready
-	out.Addresses = *(*[]v1.NodeAddress)(unsafe.Pointer(&in.Addresses))
+	out.Addresses = *(*[]corev1.NodeAddress)(unsafe.Pointer(&in.Addresses))
 	out.InstanceStatus = (*v1beta1.PacketResourceStatus)(unsafe.Pointer(in.InstanceStatus))
 	// WARNING: in.ErrorReason requires manual conversion: does not exist in peer-type
 	// WARNING: in.ErrorMessage requires manual conversion: does not exist in peer-type
@@ -396,7 +397,7 @@ func autoConvert_v1alpha3_PacketMachineStatus_To_v1beta1_PacketMachineStatus(in 
 
 func autoConvert_v1beta1_PacketMachineStatus_To_v1alpha3_PacketMachineStatus(in *v1beta1.PacketMachineStatus, out *PacketMachineStatus, s conversion.Scope) error {
 	out.Ready = in.Ready
-	out.Addresses = *(*[]v1.NodeAddress)(unsafe.Pointer(&in.Addresses))
+	out.Addresses = *(*[]corev1.NodeAddress)(unsafe.Pointer(&in.Addresses))
 	out.InstanceStatus = (*PacketResourceStatus)(unsafe.Pointer(in.InstanceStatus))
 	// WARNING: in.FailureReason requires manual conversion: does not exist in peer-type
 	// WARNING: in.FailureMessage requires manual conversion: does not exist in peer-type

--- a/api/v1beta1/packetmachine_types.go
+++ b/api/v1beta1/packetmachine_types.go
@@ -55,7 +55,7 @@ const (
 // PacketMachineSpec defines the desired state of PacketMachine.
 type PacketMachineSpec struct {
 	OS           string                              `json:"os"`
-	BillingCycle metal.DeviceCreateInputBillingCycle `json:"billingCycle"`
+	BillingCycle metal.DeviceCreateInputBillingCycle `json:"billingCycle,omitempty"`
 	MachineType  string                              `json:"machineType"`
 	SSHKeys      []string                            `json:"sshKeys,omitempty"`
 

--- a/api/v1beta1/packetmachine_types.go
+++ b/api/v1beta1/packetmachine_types.go
@@ -17,6 +17,7 @@ limitations under the License.
 package v1beta1
 
 import (
+	metal "github.com/equinix-labs/metal-go/metal/v1"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	clusterv1 "sigs.k8s.io/cluster-api/api/v1beta1"
@@ -53,10 +54,10 @@ const (
 
 // PacketMachineSpec defines the desired state of PacketMachine.
 type PacketMachineSpec struct {
-	OS           string   `json:"os"`
-	BillingCycle string   `json:"billingCycle"`
-	MachineType  string   `json:"machineType"`
-	SSHKeys      []string `json:"sshKeys,omitempty"`
+	OS           string                              `json:"os"`
+	BillingCycle metal.DeviceCreateInputBillingCycle `json:"billingCycle"`
+	MachineType  string                              `json:"machineType"`
+	SSHKeys      []string                            `json:"sshKeys,omitempty"`
 
 	// Facility represents the Packet facility for this machine.
 	// Override from the PacketCluster spec.

--- a/config/crd/bases/infrastructure.cluster.x-k8s.io_packetmachines.yaml
+++ b/config/crd/bases/infrastructure.cluster.x-k8s.io_packetmachines.yaml
@@ -62,6 +62,8 @@ spec:
               OS:
                 type: string
               billingCycle:
+                description: DeviceCreateInputBillingCycle The billing cycle of the
+                  device.
                 type: string
               facility:
                 description: Facility represents the Packet facility for this cluster.
@@ -197,6 +199,8 @@ spec:
             description: PacketMachineSpec defines the desired state of PacketMachine.
             properties:
               billingCycle:
+                description: DeviceCreateInputBillingCycle The billing cycle of the
+                  device.
                 type: string
               facility:
                 description: Facility represents the Packet facility for this machine.

--- a/config/crd/bases/infrastructure.cluster.x-k8s.io_packetmachines.yaml
+++ b/config/crd/bases/infrastructure.cluster.x-k8s.io_packetmachines.yaml
@@ -101,7 +101,6 @@ spec:
                 type: array
             required:
             - OS
-            - billingCycle
             - machineType
             type: object
           status:
@@ -239,7 +238,6 @@ spec:
                   type: string
                 type: array
             required:
-            - billingCycle
             - machineType
             - os
             type: object

--- a/config/crd/bases/infrastructure.cluster.x-k8s.io_packetmachinetemplates.yaml
+++ b/config/crd/bases/infrastructure.cluster.x-k8s.io_packetmachinetemplates.yaml
@@ -50,6 +50,8 @@ spec:
                       OS:
                         type: string
                       billingCycle:
+                        description: DeviceCreateInputBillingCycle The billing cycle
+                          of the device.
                         type: string
                       facility:
                         description: Facility represents the Packet facility for this
@@ -130,6 +132,8 @@ spec:
                       of the machine.
                     properties:
                       billingCycle:
+                        description: DeviceCreateInputBillingCycle The billing cycle
+                          of the device.
                         type: string
                       facility:
                         description: Facility represents the Packet facility for this

--- a/config/crd/bases/infrastructure.cluster.x-k8s.io_packetmachinetemplates.yaml
+++ b/config/crd/bases/infrastructure.cluster.x-k8s.io_packetmachinetemplates.yaml
@@ -90,7 +90,6 @@ spec:
                         type: array
                     required:
                     - OS
-                    - billingCycle
                     - machineType
                     type: object
                 required:
@@ -173,7 +172,6 @@ spec:
                           type: string
                         type: array
                     required:
-                    - billingCycle
                     - machineType
                     - os
                     type: object

--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module sigs.k8s.io/cluster-api-provider-packet
 go 1.19
 
 require (
-	github.com/equinix-labs/metal-go v0.25.0
+	github.com/equinix-labs/metal-go v0.25.1
 	github.com/onsi/gomega v1.27.5
 	github.com/pkg/errors v0.9.1
 	github.com/spf13/cobra v1.6.1

--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module sigs.k8s.io/cluster-api-provider-packet
 go 1.19
 
 require (
-	github.com/equinix-labs/metal-go v0.21.0
+	github.com/equinix-labs/metal-go v0.25.0
 	github.com/onsi/gomega v1.27.5
 	github.com/pkg/errors v0.9.1
 	github.com/spf13/cobra v1.6.1

--- a/go.sum
+++ b/go.sum
@@ -101,8 +101,8 @@ github.com/envoyproxy/go-control-plane v0.9.4/go.mod h1:6rpuAdCZL397s3pYoYcLgu1m
 github.com/envoyproxy/go-control-plane v0.9.9-0.20201210154907-fd9021fe5dad/go.mod h1:cXg6YxExXjJnVBQHBLXeUAgxn2UodCpnH306RInaBQk=
 github.com/envoyproxy/go-control-plane v0.9.9-0.20210512163311-63b5d3c536b0/go.mod h1:hliV/p42l8fGbc6Y9bQ70uLwIvmJyVE5k4iMKlh8wCQ=
 github.com/envoyproxy/protoc-gen-validate v0.1.0/go.mod h1:iSmxcyjqTsJpI2R4NaDN7+kN2VEUnK/pcBlmesArF7c=
-github.com/equinix-labs/metal-go v0.21.0 h1:AWmciCaO+tjNKCKB0r4pMHpoGenzAqua3TbXA5VjZE8=
-github.com/equinix-labs/metal-go v0.21.0/go.mod h1:SmxCklxW+KjmBLVMdEXgtFO5gD5/b4N0VxcNgUYbOH4=
+github.com/equinix-labs/metal-go v0.25.0 h1:AgMwoRYhfqPSkGu1FFLlyVCFBRy/xiBgnfiydMtw7jY=
+github.com/equinix-labs/metal-go v0.25.0/go.mod h1:SmxCklxW+KjmBLVMdEXgtFO5gD5/b4N0VxcNgUYbOH4=
 github.com/evanphx/json-patch v0.5.2/go.mod h1:ZWS5hhDbVDyob71nXKNL0+PWn6ToqBHMikGIFbs31qQ=
 github.com/evanphx/json-patch v5.6.0+incompatible h1:jBYDEEiFBPxA0v50tFdvOzQQTCvpL6mnFh5mB2/l16U=
 github.com/evanphx/json-patch v5.6.0+incompatible/go.mod h1:50XU6AFN0ol/bzJsmQLiYLvXMP4fmwYFNcr97nuDLSk=

--- a/go.sum
+++ b/go.sum
@@ -101,8 +101,8 @@ github.com/envoyproxy/go-control-plane v0.9.4/go.mod h1:6rpuAdCZL397s3pYoYcLgu1m
 github.com/envoyproxy/go-control-plane v0.9.9-0.20201210154907-fd9021fe5dad/go.mod h1:cXg6YxExXjJnVBQHBLXeUAgxn2UodCpnH306RInaBQk=
 github.com/envoyproxy/go-control-plane v0.9.9-0.20210512163311-63b5d3c536b0/go.mod h1:hliV/p42l8fGbc6Y9bQ70uLwIvmJyVE5k4iMKlh8wCQ=
 github.com/envoyproxy/protoc-gen-validate v0.1.0/go.mod h1:iSmxcyjqTsJpI2R4NaDN7+kN2VEUnK/pcBlmesArF7c=
-github.com/equinix-labs/metal-go v0.25.0 h1:AgMwoRYhfqPSkGu1FFLlyVCFBRy/xiBgnfiydMtw7jY=
-github.com/equinix-labs/metal-go v0.25.0/go.mod h1:SmxCklxW+KjmBLVMdEXgtFO5gD5/b4N0VxcNgUYbOH4=
+github.com/equinix-labs/metal-go v0.25.1 h1:uL83lRKyAcOfab+9r2xujAuLD8lTsqv89+SPvVFkcBM=
+github.com/equinix-labs/metal-go v0.25.1/go.mod h1:SmxCklxW+KjmBLVMdEXgtFO5gD5/b4N0VxcNgUYbOH4=
 github.com/evanphx/json-patch v0.5.2/go.mod h1:ZWS5hhDbVDyob71nXKNL0+PWn6ToqBHMikGIFbs31qQ=
 github.com/evanphx/json-patch v5.6.0+incompatible h1:jBYDEEiFBPxA0v50tFdvOzQQTCvpL6mnFh5mB2/l16U=
 github.com/evanphx/json-patch v5.6.0+incompatible/go.mod h1:50XU6AFN0ol/bzJsmQLiYLvXMP4fmwYFNcr97nuDLSk=

--- a/pkg/cloud/packet/client.go
+++ b/pkg/cloud/packet/client.go
@@ -302,7 +302,7 @@ func (p *Client) EnableProjectBGP(ctx context.Context, projectID string) error {
 	// - bgpConfig struct does not have Status=="disabled"
 	if err != nil {
 		return err
-	} else if bgpConfig != nil && bgpConfig.GetId() != "" && strings.ToLower(bgpConfig.GetStatus()) != "disabled" {
+	} else if bgpConfig != nil && bgpConfig.GetId() != "" && bgpConfig.GetStatus() != metal.BGPCONFIGSTATUS_DISABLED {
 		return nil
 	}
 
@@ -341,7 +341,7 @@ func (p *Client) EnableProjectBGP(ctx context.Context, projectID string) error {
 // EnsureNodeBGPEnabled check if the node has bgp enabled, and set it if it does not.
 func (p *Client) EnsureNodeBGPEnabled(ctx context.Context, id string) error {
 	// fortunately, this is idempotent, so just create
-	addressFamily := "ipv4"
+	addressFamily := metal.BGPSESSIONINPUTADDRESSFAMILY_IPV4
 	req := metal.BGPSessionInput{
 		AddressFamily: &addressFamily,
 	}

--- a/test/e2e/go.mod
+++ b/test/e2e/go.mod
@@ -8,7 +8,7 @@ replace (
 )
 
 require (
-	github.com/equinix-labs/metal-go v0.25.0
+	github.com/equinix-labs/metal-go v0.25.1
 	github.com/onsi/ginkgo/v2 v2.9.2
 	github.com/onsi/gomega v1.27.5
 	golang.org/x/crypto v0.12.0

--- a/test/e2e/go.sum
+++ b/test/e2e/go.sum
@@ -130,8 +130,8 @@ github.com/envoyproxy/go-control-plane v0.9.7/go.mod h1:cwu0lG7PUMfa9snN8LXBig5y
 github.com/envoyproxy/go-control-plane v0.9.9-0.20201210154907-fd9021fe5dad/go.mod h1:cXg6YxExXjJnVBQHBLXeUAgxn2UodCpnH306RInaBQk=
 github.com/envoyproxy/go-control-plane v0.9.9-0.20210512163311-63b5d3c536b0/go.mod h1:hliV/p42l8fGbc6Y9bQ70uLwIvmJyVE5k4iMKlh8wCQ=
 github.com/envoyproxy/protoc-gen-validate v0.1.0/go.mod h1:iSmxcyjqTsJpI2R4NaDN7+kN2VEUnK/pcBlmesArF7c=
-github.com/equinix-labs/metal-go v0.25.0 h1:AgMwoRYhfqPSkGu1FFLlyVCFBRy/xiBgnfiydMtw7jY=
-github.com/equinix-labs/metal-go v0.25.0/go.mod h1:SmxCklxW+KjmBLVMdEXgtFO5gD5/b4N0VxcNgUYbOH4=
+github.com/equinix-labs/metal-go v0.25.1 h1:uL83lRKyAcOfab+9r2xujAuLD8lTsqv89+SPvVFkcBM=
+github.com/equinix-labs/metal-go v0.25.1/go.mod h1:SmxCklxW+KjmBLVMdEXgtFO5gD5/b4N0VxcNgUYbOH4=
 github.com/evanphx/json-patch v0.5.2/go.mod h1:ZWS5hhDbVDyob71nXKNL0+PWn6ToqBHMikGIFbs31qQ=
 github.com/evanphx/json-patch v5.6.0+incompatible h1:jBYDEEiFBPxA0v50tFdvOzQQTCvpL6mnFh5mB2/l16U=
 github.com/evanphx/json-patch v5.6.0+incompatible/go.mod h1:50XU6AFN0ol/bzJsmQLiYLvXMP4fmwYFNcr97nuDLSk=


### PR DESCRIPTION
<!-- please add an icon to the title of this PR (see https://sigs.k8s.io/cluster-api/CONTRIBUTING.md#contributing-a-patch), and delete this line and similar ones -->
<!-- the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) -->

**What this PR does / why we need it**:
Bumps our metal-go dep to v0.25.0.
Updates a few lines of code to be compatible with type changes.