### PR TITLE
:seedling: bump dockerfile to use Go 1.20

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-# syntax=docker/dockerfile:1.1
+# syntax=docker/dockerfile:1
 
 # Copyright 2020 The Kubernetes Authors.
 #

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-# syntax=docker/dockerfile:1.1-experimental
+# syntax=docker/dockerfile:1.1
 
 # Copyright 2020 The Kubernetes Authors.
 #
@@ -15,7 +15,7 @@
 # limitations under the License.
 
 # Build the manager binary
-ARG GOVER=1.19.7
+ARG GOVER=1.20.10
 FROM golang:${GOVER} as builder
 
 WORKDIR /workspace

--- a/hack/boilerplate/boilerplate.Dockerfile.txt
+++ b/hack/boilerplate/boilerplate.Dockerfile.txt
@@ -1,4 +1,4 @@
-# syntax=docker/dockerfile:1.1-experimental
+# syntax=docker/dockerfile:1
 
 # Copyright YEAR The Kubernetes Authors.
 #


### PR DESCRIPTION

**What this PR does / why we need it**:
- Bumps dockerfile to use 1.20.10 as base builder image
- Also use current dockerfile builder syntax