### PR TITLE
:seedling: bump tags for 0.8.0 release

### DIFF
--- a/metadata.yaml
+++ b/metadata.yaml
@@ -7,6 +7,9 @@ apiVersion: clusterctl.cluster.x-k8s.io/v1alpha3
 kind: Metadata
 releaseSeries:
 - major: 0
+  minor: 8
+  contract: v1beta1
+- major: 0
   minor: 7
   contract: v1beta1
 - major: 0

--- a/test/e2e/config/packet-ci-actions.yaml
+++ b/test/e2e/config/packet-ci-actions.yaml
@@ -52,7 +52,7 @@ providers:
   - name: packet
     type: InfrastructureProvider
     versions:
-      - name: v0.7.2
+      - name: v0.8.0
         value: "${MANIFEST_PATH:=..}/infrastructure-components.yaml"
         type: "url"
         contract: v1beta1
@@ -63,7 +63,7 @@ providers:
           - sourcePath: "../data/v1beta1/cluster-template-node-drain.yaml"
           - sourcePath: "../data/v1beta1/cluster-template-md-remediation.yaml"
           - sourcePath: "../data/v1beta1/cluster-template-kcp-remediation.yaml"
-      - name: v0.7.99 # next; use manifest from source files
+      - name: v0.8.99 # next; use manifest from source files
         value: "${MANIFEST_PATH:=..}/infrastructure-components.yaml"
         type: "url"
         contract: v1beta1

--- a/test/e2e/config/packet-ci.yaml
+++ b/test/e2e/config/packet-ci.yaml
@@ -52,7 +52,7 @@ providers:
   - name: packet
     type: InfrastructureProvider
     versions:
-      - name: v0.7.2 #latest in the v1beta1 series
+      - name: v0.8.0 #latest in the v1beta1 series
         value: "../../../config/default"
         replacements:
           - old: "image: .*/cluster-api-provider-packet:.*"
@@ -65,7 +65,7 @@ providers:
           - sourcePath: "../data/v1beta1/cluster-template-node-drain.yaml"
           - sourcePath: "../data/v1beta1/cluster-template-md-remediation.yaml"
           - sourcePath: "../data/v1beta1/cluster-template-kcp-remediation.yaml"
-      - name: v0.7.99 # next; use manifest from source files
+      - name: v0.8.99 # next; use manifest from source files
         value: "../../../config/default"
         replacements:
           - old: "image: .*/cluster-api-provider-packet:.*"


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR adds the v0.8.0 version of CAPP to the metadata.yaml file and configures the E2E test config files to use the v0.8.0 version of CAPP.

Directions came from: https://github.com/kubernetes-sigs/cluster-api-provider-packet/blob/main/docs/RELEASE.md