### PR TITLE
:seedling: feat: Update to upstream's new dependabot file to reduce frequency and amount of dependabot PRs

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -2,82 +2,65 @@
 # https://docs.github.com/github/administering-a-repository/configuration-options-for-dependency-updates
 version: 2
 updates:
-# GitHub Actions
-- package-ecosystem: "github-actions"
-  directory: "/"
-  schedule:
+  # GitHub Actions
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
       interval: "weekly"
-  commit-message:
+    groups:
+      all-github-actions:
+        patterns: ["*"]
+    commit-message:
       prefix: ":seedling:"
-  labels:
-    - "area/ci"
-    - "ok-to-test"
-# Go
-- package-ecosystem: "gomod"
-  directory: "/"
-  schedule:
-    interval: "weekly"
-    day: "monday"
-  ## group all dependencies with a k8s.io prefix into a single PR.
-  groups:
-    kubernetes:
-      patterns: [ "k8s.io/*" ]
-  ignore:
-  # Ignore controller-runtime as its upgraded manually.
-  - dependency-name: "sigs.k8s.io/controller-runtime"
-    update-types: [ "version-update:semver-major", "version-update:semver-minor" ]
-    # Ignore k8s and its transitives modules as they are upgraded manually together with controller-runtime.
-  - dependency-name: "k8s.io/*"
-    update-types: [ "version-update:semver-major", "version-update:semver-minor" ]
-  - dependency-name: "go.etcd.io/*"
-    update-types: [ "version-update:semver-major", "version-update:semver-minor" ]
-  - dependency-name: "google.golang.org/grpc"
-    update-types: [ "version-update:semver-major", "version-update:semver-minor" ]
-    # Bumping the kustomize API independently can break compatibility with client-go as they share k8s.io/kube-openapi as a dependency.
-  - dependency-name: "sigs.k8s.io/kustomize/api"
-    update-types: [ "version-update:semver-major", "version-update:semver-minor" ]
-  commit-message:
-    prefix: ":seedling:"
-  labels:
-    - "area/dependency"
-    - "ok-to-test"
-  
-# Maintain e2e test Go modules
-- package-ecosystem: "gomod"
-  directory: "/test/e2e"
-  schedule:
-    interval: "weekly"
-    day: "tuesday"
-  ## group all dependencies with a k8s.io prefix into a single PR.
-  groups:
-    kubernetes:
-      patterns: [ "k8s.io/*" ]
-  ignore:
-    # Ignore controller-runtime as its upgraded manually.
-    - dependency-name: "sigs.k8s.io/controller-runtime"
-      update-types: [ "version-update:semver-major", "version-update:semver-minor" ]
-    # Ignore k8s and its transitives modules as they are upgraded manually together with controller-runtime.
-    - dependency-name: "k8s.io/*"
-      update-types: [ "version-update:semver-major", "version-update:semver-minor" ]
-    - dependency-name: "go.etcd.io/*"
-      update-types: [ "version-update:semver-major", "version-update:semver-minor" ]
-    - dependency-name: "google.golang.org/grpc"
-      update-types: [ "version-update:semver-major", "version-update:semver-minor" ]
-    # Bumping the kustomize API independently can break compatibility with client-go as they share k8s.io/kube-openapi as a dependency.
-    - dependency-name: "sigs.k8s.io/kustomize/api"
-      update-types: [ "version-update:semver-major", "version-update:semver-minor" ]
-  commit-message:
-    prefix: ":seedling:"
-  labels:
-    - "area/dependency"
-    - "ok-to-test"
-  
-# Maintain dependencies for Docker images.
-- package-ecosystem: "docker"
-  directory: "/"
-  schedule:
-    interval: "weekly"
-  commit-message:
-    prefix: ":seedling:"
-  labels:
-    - "ok-to-test"
+    labels:
+      - "area/ci"
+      - "ok-to-test"
+
+  # Go modules
+  - package-ecosystem: "gomod"
+    directories:
+      - "/"
+      - "/test"
+      - "/hack/tools"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+    ## group all dependencies with a k8s.io prefix into a single PR.
+    groups:
+      all-go-mod-patch-and-minor:
+        patterns: ["*"]
+        update-types: ["patch", "minor"]
+    ignore:
+      # Ignore controller-runtime as its upgraded manually.
+      - dependency-name: "sigs.k8s.io/controller-runtime"
+        update-types:
+          ["version-update:semver-major", "version-update:semver-minor"]
+        # Ignore k8s and its transitives modules as they are upgraded manually together with controller-runtime.
+      - dependency-name: "k8s.io/*"
+        update-types:
+          ["version-update:semver-major", "version-update:semver-minor"]
+      - dependency-name: "go.etcd.io/*"
+        update-types:
+          ["version-update:semver-major", "version-update:semver-minor"]
+      - dependency-name: "google.golang.org/grpc"
+        update-types:
+          ["version-update:semver-major", "version-update:semver-minor"]
+        # Bumping the kustomize API independently can break compatibility with client-go as they share k8s.io/kube-openapi as a dependency.
+      - dependency-name: "sigs.k8s.io/kustomize/api"
+        update-types:
+          ["version-update:semver-major", "version-update:semver-minor"]
+    commit-message:
+      prefix: ":seedling:"
+    labels:
+      - "area/dependency"
+      - "ok-to-test"
+
+  # Maintain dependencies for Docker images.
+  - package-ecosystem: "docker"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    commit-message:
+      prefix: ":seedling:"
+    labels:
+      - "ok-to-test"


### PR DESCRIPTION
<!-- please add an icon to the title of this PR (see https://sigs.k8s.io/cluster-api/CONTRIBUTING.md#contributing-a-patch), and delete this line and similar ones -->
<!-- the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) -->

**What this PR does / why we need it**: This PR updates CAPP's dependabot config to the new config used by upstream Cluster API. This is to get their latest optimizations to reduce the amount and frequency of dependabot PRs while still receiving important updates.