### PR TITLE
:sparkles: Add EMLB based templates for testing and deployment

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -225,6 +225,7 @@ e2e-test-templates-v1beta1: $(KUSTOMIZE) ## Generate cluster templates for v1bet
 	mkdir -p $(TEST_TEMPLATES_TARGET_DIR)/v1beta1/
 	$(KUSTOMIZE) build $(REPO_ROOT)/templates/experimental-crs-cni --load-restrictor LoadRestrictionsNone > $(TEST_TEMPLATES_TARGET_DIR)/v1beta1/cluster-template.yaml
 	$(KUSTOMIZE) build $(REPO_ROOT)/templates/experimental-kube-vip-crs-cni --load-restrictor LoadRestrictionsNone > $(TEST_TEMPLATES_TARGET_DIR)/v1beta1/cluster-template-kube-vip.yaml
+	$(KUSTOMIZE) build $(REPO_ROOT)/templates/experimental-emlb-crs-cni --load-restrictor LoadRestrictionsNone > $(TEST_TEMPLATES_TARGET_DIR)/v1beta1/cluster-template-emlb.yaml
 	$(KUSTOMIZE) build $(REPO_ROOT)/test/e2e/data/v1beta1/cluster-template-kcp-scale-in --load-restrictor LoadRestrictionsNone > $(TEST_TEMPLATES_TARGET_DIR)/v1beta1/cluster-template-kcp-scale-in.yaml
 	$(KUSTOMIZE) build $(REPO_ROOT)/test/e2e/data/v1beta1/cluster-template-node-drain --load-restrictor LoadRestrictionsNone > $(TEST_TEMPLATES_TARGET_DIR)/v1beta1/cluster-template-node-drain.yaml
 	$(KUSTOMIZE) build $(REPO_ROOT)/test/e2e/data/v1beta1/cluster-template-md-remediation --load-restrictor LoadRestrictionsNone > $(TEST_TEMPLATES_TARGET_DIR)/v1beta1/cluster-template-md-remediation.yaml
@@ -282,6 +283,8 @@ generate: ## Generate code
 
 .PHONY: generate-templates
 generate-templates: $(KUSTOMIZE) ## Generate cluster templates
+	$(KUSTOMIZE) build templates/experimental-emlb --load-restrictor LoadRestrictionsNone > templates/cluster-template-emlb.yaml
+	$(KUSTOMIZE) build templates/experimental-emlb-crs-cni --load-restrictor LoadRestrictionsNone > templates/cluster-template-emlb-crs-cni.yaml
 	$(KUSTOMIZE) build templates/experimental-kube-vip-crs-cni --load-restrictor LoadRestrictionsNone > templates/cluster-template-kube-vip-crs-cni.yaml
 	$(KUSTOMIZE) build templates/experimental-kube-vip --load-restrictor LoadRestrictionsNone > templates/cluster-template-kube-vip.yaml
 	$(KUSTOMIZE) build templates/experimental-crs-cni --load-restrictor LoadRestrictionsNone > templates/cluster-template-crs-cni.yaml

--- a/api/v1beta1/packetcluster_types.go
+++ b/api/v1beta1/packetcluster_types.go
@@ -27,6 +27,12 @@ const (
 	ClusterFinalizer = "packetcluster.infrastructure.cluster.x-k8s.io"
 	// NetworkInfrastructureReadyCondition reports of current status of cluster infrastructure.
 	NetworkInfrastructureReadyCondition clusterv1.ConditionType = "NetworkInfrastructureReady"
+	// EMLBVIPID is the string used to refer to the EMLB load balancer and VIP Manager type.
+	EMLBVIPID = "EMLB"
+	// CPEMID is the string used to refer to the CPEM load balancer and VIP Manager type.
+	CPEMID = "CPEM"
+	// KUBEVIPID is the string used to refer to the Kube VIP load balancer and VIP Manager type.
+	KUBEVIPID = "KUBE_VIP"
 )
 
 // VIPManagerType describes if the VIP will be managed by CPEM or kube-vip or Equinix Metal Load Balancer.

--- a/controllers/packetcluster_controller.go
+++ b/controllers/packetcluster_controller.go
@@ -125,7 +125,7 @@ func (r *PacketClusterReconciler) reconcileNormal(ctx context.Context, clusterSc
 	packetCluster := clusterScope.PacketCluster
 
 	switch {
-	case packetCluster.Spec.VIPManager == emlb.EMLBVIPID:
+	case packetCluster.Spec.VIPManager == infrav1.EMLBVIPID:
 		if !packetCluster.Spec.ControlPlaneEndpoint.IsValid() {
 			// Create new EMLB object
 			lb := emlb.NewEMLB(r.PacketClient.GetConfig().DefaultHeader["X-Auth-Token"], packetCluster.Spec.ProjectID, packetCluster.Spec.Metro)
@@ -135,7 +135,7 @@ func (r *PacketClusterReconciler) reconcileNormal(ctx context.Context, clusterSc
 				return err
 			}
 		}
-	case packetCluster.Spec.VIPManager == "KUBE_VIP":
+	case packetCluster.Spec.VIPManager == infrav1.KUBEVIPID:
 		log.Info("KUBE_VIP VIPManager Detected")
 		if err := r.PacketClient.EnableProjectBGP(ctx, packetCluster.Spec.ProjectID); err != nil {
 			log.Error(err, "error enabling bgp for project")
@@ -143,7 +143,7 @@ func (r *PacketClusterReconciler) reconcileNormal(ctx context.Context, clusterSc
 		}
 	}
 
-	if packetCluster.Spec.VIPManager != emlb.EMLBVIPID {
+	if packetCluster.Spec.VIPManager != infrav1.EMLBVIPID {
 		ipReserv, err := r.PacketClient.GetIPByClusterIdentifier(ctx, clusterScope.Namespace(), clusterScope.Name(), packetCluster.Spec.ProjectID)
 		switch {
 		case errors.Is(err, packet.ErrControlPlanEndpointNotFound):
@@ -192,7 +192,7 @@ func (r *PacketClusterReconciler) reconcileDelete(ctx context.Context, clusterSc
 
 	packetCluster := clusterScope.PacketCluster
 
-	if packetCluster.Spec.VIPManager == emlb.EMLBVIPID {
+	if packetCluster.Spec.VIPManager == infrav1.EMLBVIPID {
 		// Create new EMLB object
 		lb := emlb.NewEMLB(r.PacketClient.GetConfig().DefaultHeader["X-Auth-Token"], packetCluster.Spec.ProjectID, packetCluster.Spec.Metro)
 

--- a/controllers/packetmachine_controller.go
+++ b/controllers/packetmachine_controller.go
@@ -368,6 +368,8 @@ func (r *PacketMachineReconciler) reconcile(ctx context.Context, machineScope *s
 					addrs = append(addrs, a)
 				}
 				controlPlaneEndpointAddress = controlPlaneEndpoint.GetAddress()
+			case machineScope.PacketCluster.Spec.VIPManager == "KUBE_VIP":
+				controlPlaneEndpointAddress = controlPlaneEndpoint.GetAddress()
 			case machineScope.PacketCluster.Spec.VIPManager == emlb.EMLBVIPID:
 				controlPlaneEndpointAddress = machineScope.Cluster.Spec.ControlPlaneEndpoint.Host
 				cpemLBConfig = "emlb:///" + machineScope.PacketCluster.Spec.Metro

--- a/controllers/packetmachine_controller.go
+++ b/controllers/packetmachine_controller.go
@@ -544,11 +544,13 @@ func (r *PacketMachineReconciler) reconcileDelete(ctx context.Context, machineSc
 	}
 
 	if machineScope.PacketCluster.Spec.VIPManager == infrav1.EMLBVIPID {
-		// Create new EMLB object
-		lb := emlb.NewEMLB(r.PacketClient.GetConfig().DefaultHeader["X-Auth-Token"], machineScope.PacketCluster.Spec.ProjectID, packetmachine.Spec.Metro)
+		if machineScope.IsControlPlane() {
+			// Create new EMLB object
+			lb := emlb.NewEMLB(r.PacketClient.GetConfig().DefaultHeader["X-Auth-Token"], machineScope.PacketCluster.Spec.ProjectID, packetmachine.Spec.Metro)
 
-		if err := lb.DeleteLoadBalancerOrigin(ctx, machineScope); err != nil {
-			return fmt.Errorf("failed to delete load balancer origin: %w", err)
+			if err := lb.DeleteLoadBalancerOrigin(ctx, machineScope); err != nil {
+				return fmt.Errorf("failed to delete load balancer origin: %w", err)
+			}
 		}
 	}
 

--- a/docs/experiences/flavors.md
+++ b/docs/experiences/flavors.md
@@ -4,15 +4,29 @@
 
 ### API Server VIP Management Choice
 
-By default CPEM will be used to manage the EIP that serves as the VIP for the api-server. As of v0.6.0 you can choose to use kube-vip to manage the api-server VIP instead of CPEM.
+By default CPEM will be used to manage the EIP that serves as the VIP for the api-server. Other flavors include kube-vip and Equinix Metal Load Balancer.
 
-### Choosing Kube-VIP
+### Choosing Equinix Metal Load Balancer
 
- To use kube-vip, when generating the template with `clusterctl`, pass in the `--flavor kube-vip` flag. For example, your `clusterctl generate` command might look like the following:
+To use Equinix Metal Load Balancer, when generating the template with `clusterctl`, pass in the `--flavor emlb` flag. For example, your `clusterctl generate` command might look like the following:
 
 ```sh
 clusterctl generate cluster capi-quickstart \
-  --kubernetes-version v1.24.0 \
+  --kubernetes-version v1.31.0 \
+  --control-plane-machine-count=3 \
+  --worker-machine-count=3 \
+  --infrastructure packet \
+  --flavor emlb
+  > capi-quickstart.yaml
+```
+
+### Choosing Kube-VIP
+
+To use kube-vip, when generating the template with `clusterctl`, pass in the `--flavor kube-vip` flag. For example, your `clusterctl generate` command might look like the following:
+
+```sh
+clusterctl generate cluster capi-quickstart \
+  --kubernetes-version v1.31.0 \
   --control-plane-machine-count=3 \
   --worker-machine-count=3 \
   --infrastructure packet \

--- a/internal/emlb/emlb.go
+++ b/internal/emlb/emlb.go
@@ -49,8 +49,6 @@ const (
 	loadBalancerPoolIDAnnotation = "equinix.com/loadbalancerpoolID"
 	// loadBalancerPoolOriginIDAnnotation is the anotation key representing the origin ID of a PacketMachine.
 	loadBalancerOriginIDAnnotation = "equinix.com/loadbalanceroriginID"
-	// EMLBVIPID is the stringused to refer to the EMLB load balancer and VIP Manager type.
-	EMLBVIPID = "EMLB"
 	// loadbalancerTokenExchangeURL is the default URL to use for Token Exchange to talk to the Equinix Metal Load Balancer API.
 	loadbalancerTokenExchnageURL = "https://iam.metalctrl.io/api-keys/exchange" //nolint:gosec
 )

--- a/templates/cluster-template-emlb-crs-cni.yaml
+++ b/templates/cluster-template-emlb-crs-cni.yaml
@@ -1,3 +1,22 @@
+apiVersion: v1
+data: ${CNI_RESOURCES}
+kind: ConfigMap
+metadata:
+  name: ${CLUSTER_NAME}-crs-cni
+---
+apiVersion: addons.cluster.x-k8s.io/v1beta1
+kind: ClusterResourceSet
+metadata:
+  name: ${CLUSTER_NAME}-crs-cni
+spec:
+  clusterSelector:
+    matchLabels:
+      cni: ${CLUSTER_NAME}-crs-cni
+  resources:
+  - kind: ConfigMap
+    name: ${CLUSTER_NAME}-crs-cni
+  strategy: ApplyOnce
+---
 apiVersion: bootstrap.cluster.x-k8s.io/v1beta1
 kind: KubeadmConfigTemplate
 metadata:
@@ -55,6 +74,8 @@ spec:
 apiVersion: cluster.x-k8s.io/v1beta1
 kind: Cluster
 metadata:
+  labels:
+    cni: ${CLUSTER_NAME}-crs-cni
   name: ${CLUSTER_NAME}
 spec:
   clusterNetwork:

--- a/templates/experimental-emlb-crs-cni/kustomization.yaml
+++ b/templates/experimental-emlb-crs-cni/kustomization.yaml
@@ -1,0 +1,16 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+resources:
+  - ../experimental-emlb
+  - ../bases/crs-cni.yaml
+patches:
+  - patch: |-
+      kind: Cluster
+      apiVersion: cluster.x-k8s.io/v1beta1
+      metadata:
+        name: not-used
+        labels:
+          cni: "${CLUSTER_NAME}-crs-cni"
+    target:
+      kind: Cluster

--- a/templates/experimental-emlb/kustomization.yaml
+++ b/templates/experimental-emlb/kustomization.yaml
@@ -1,0 +1,82 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+resources:
+  - ../cluster-template.yaml
+patches:
+  - patch: |-
+      apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+      kind: PacketCluster
+      metadata:
+        name: "${CLUSTER_NAME}"
+      spec:
+        vipManager: "EMLB"
+  - patch: |-
+      kind: KubeadmControlPlane
+      apiVersion: controlplane.cluster.x-k8s.io/v1beta1
+      metadata:
+        name: "${CLUSTER_NAME}-control-plane"
+      spec:
+        kubeadmConfigSpec:
+          preKubeadmCommands:
+            - |
+              sed -ri '/\sswap\s/s/^#?/#/' /etc/fstab
+              swapoff -a
+              mount -a
+              cat <<EOF > /etc/modules-load.d/containerd.conf
+              overlay
+              br_netfilter
+              EOF
+              modprobe overlay
+              modprobe br_netfilter
+              cat <<EOF > /etc/sysctl.d/99-kubernetes-cri.conf
+              net.bridge.bridge-nf-call-iptables  = 1
+              net.ipv4.ip_forward                 = 1
+              net.bridge.bridge-nf-call-ip6tables = 1
+              EOF
+              sysctl --system
+              export DEBIAN_FRONTEND=noninteractive
+              apt-get update -y
+              apt-get remove -y docker docker-engine containerd runc
+              apt-get install -y apt-transport-https ca-certificates curl gnupg lsb-release linux-generic jq
+              major_vers=$(lsb_release -r | awk '{ print $2 }' | cut -d. -f1)
+              if [ "$major_vers" -ge 20 ]; then
+                apt-get install -y kubetail
+              fi
+              install -m 0755 -d /etc/apt/keyrings
+              curl -fsSL https://download.docker.com/linux/ubuntu/gpg | gpg --dearmor -o /etc/apt/keyrings/docker.gpg
+              MINOR_KUBERNETES_VERSION=$(echo {{ .kubernetesVersion }} | cut -d. -f1-2 )
+              curl -fsSL https://pkgs.k8s.io/core:/stable:/$${MINOR_KUBERNETES_VERSION}/deb/Release.key | gpg --dearmor -o /etc/apt/keyrings/kubernetes-apt-keyring.gpg
+              chmod a+r /etc/apt/keyrings/docker.gpg
+              chmod a+r /etc/apt/keyrings/kubernetes-archive-keyring.gpg
+              echo "deb [arch="$(dpkg --print-architecture)" signed-by=/etc/apt/keyrings/docker.gpg] https://download.docker.com/linux/ubuntu "$(. /etc/os-release && echo "$VERSION_CODENAME")" stable" > /etc/apt/sources.list.d/docker.list
+              echo "deb [signed-by=/etc/apt/keyrings/kubernetes-apt-keyring.gpg] https://pkgs.k8s.io/core:/stable:/$${MINOR_KUBERNETES_VERSION}/deb/ /" > /etc/apt/sources.list.d/kubernetes.list
+              apt-get update -y
+              TRIMMED_KUBERNETES_VERSION=$(echo {{ .kubernetesVersion }} | sed 's/\./\\\\./g' | sed 's/^v//')
+              RESOLVED_KUBERNETES_VERSION=$(apt-cache madison kubelet | awk -v VERSION=$${TRIMMED_KUBERNETES_VERSION} '$3~ VERSION { print $3 }' | head -n1)
+              apt-get install -y containerd.io kubelet=$${RESOLVED_KUBERNETES_VERSION} kubeadm=$${RESOLVED_KUBERNETES_VERSION} kubectl=$${RESOLVED_KUBERNETES_VERSION}
+              containerd config default > /etc/containerd/config.toml
+              cat  <<EOF > /etc/crictl.yaml
+              runtime-endpoint: unix:///run/containerd/containerd.sock
+              image-endpoint: unix:///run/containerd/containerd.sock
+              EOF
+              sed -i 's/SystemdCgroup = false/SystemdCgroup = true/' /etc/containerd/config.toml
+              sed -i "s,sandbox_image.*$,sandbox_image = \"$(kubeadm config images list | grep pause | sort -r | head -n1)\"," /etc/containerd/config.toml
+              systemctl restart containerd
+              if [ -f "/run/kubeadm/kubeadm.yaml" ]; then
+                ip addr add {{ .controlPlaneEndpoint }} dev lo
+              fi
+          postKubeadmCommands:
+            - |
+              mkdir -p $HOME/.kube
+              cp /etc/kubernetes/admin.conf $HOME/.kube/config
+              echo "source <(kubectl completion bash)" >> $HOME/.bashrc
+              echo "alias k=kubectl" >> $HOME/.bashrc
+              echo "complete -o default -F __start_kubectl k" >> $HOME/.bashrc
+              if [ -f "/run/kubeadm/kubeadm.yaml" ]; then
+                export KUBECONFIG=/etc/kubernetes/admin.conf
+                export CPEM_YAML=https://github.com/equinix/cloud-provider-equinix-metal/releases/download/${CPEM_VERSION:=v3.8.0}/deployment.yaml
+                export SECRET_DATA='cloud-sa.json=''{"apiKey": "{{ .apiKey }}","projectID": "${PROJECT_ID}"}'''
+                kubectl create secret generic -n kube-system metal-cloud-config --from-literal="$${SECRET_DATA}" || (sleep 1 && kubectl create secret generic -n kube-system metal-cloud-config --from-literal="$${SECRET_DATA}") || (sleep 1 && kubectl create secret generic -n kube-system metal-cloud-config --from-literal="$${SECRET_DATA}")
+                kubectl apply -f $${CPEM_YAML} || (sleep 1 && kubectl apply -f $${CPEM_YAML}) || (sleep 1 && kubectl apply -f $${CPEM_YAML})
+              fi

--- a/test/e2e/capi_e2e_quickstart_test.go
+++ b/test/e2e/capi_e2e_quickstart_test.go
@@ -54,4 +54,17 @@ var _ = Describe("[QuickStart] Running the Cluster API E2E QuickStart tests", fu
 			}
 		})
 	})
+
+	Context("Running the [EMLB] quickstart spec", func() {
+		capi_e2e.QuickStartSpec(ctx, func() capi_e2e.QuickStartSpecInput {
+			return capi_e2e.QuickStartSpecInput{
+				E2EConfig:             e2eConfig,
+				ClusterctlConfigPath:  clusterctlConfigPath,
+				BootstrapClusterProxy: bootstrapClusterProxy,
+				ArtifactFolder:        artifactFolder,
+				SkipCleanup:           skipCleanup,
+				Flavor:                ptr.To[string]("emlb"),
+			}
+		})
+	})
 })

--- a/test/e2e/config/packet-ci-actions.yaml
+++ b/test/e2e/config/packet-ci-actions.yaml
@@ -70,6 +70,7 @@ providers:
         files:
           - sourcePath: "${MANIFEST_PATH:=..}/metadata.yaml"
           - sourcePath: "../data/v1beta1/cluster-template.yaml"
+          - sourcePath: "../data/v1beta1/cluster-template-emlb.yaml"
           - sourcePath: "../data/v1beta1/cluster-template-kube-vip.yaml"
           - sourcePath: "../data/v1beta1/cluster-template-kcp-scale-in.yaml"
           - sourcePath: "../data/v1beta1/cluster-template-node-drain.yaml"

--- a/test/e2e/config/packet-ci.yaml
+++ b/test/e2e/config/packet-ci.yaml
@@ -74,6 +74,7 @@ providers:
         files:
           - sourcePath: "../../../metadata.yaml"
           - sourcePath: "../data/v1beta1/cluster-template.yaml"
+          - sourcePath: "../data/v1beta1/cluster-template-emlb.yaml"
           - sourcePath: "../data/v1beta1/cluster-template-kube-vip.yaml"
           - sourcePath: "../data/v1beta1/cluster-template-kcp-scale-in.yaml"
           - sourcePath: "../data/v1beta1/cluster-template-node-drain.yaml"
@@ -88,6 +89,7 @@ providers:
         files:
           - sourcePath: "../../../metadata.yaml"
           - sourcePath: "../data/v1beta1/cluster-template.yaml"
+          - sourcePath: "../data/v1beta1/cluster-template-emlb.yaml"
           - sourcePath: "../data/v1beta1/cluster-template-kube-vip.yaml"
           - sourcePath: "../data/v1beta1/cluster-template-kcp-scale-in.yaml"
           - sourcePath: "../data/v1beta1/cluster-template-node-drain.yaml"

--- a/test/e2e/data/v1beta1/cluster-template-emlb/kustomization.yaml
+++ b/test/e2e/data/v1beta1/cluster-template-emlb/kustomization.yaml
@@ -1,0 +1,3 @@
+resources:
+  - ../../../../../templates/experimental-emlb
+  - ../bases/kcp-mhc.yaml


### PR DESCRIPTION
Signed-off-by: Chris Privitere <23177737+cprivitere@users.noreply.github.com>

<!-- please add an icon to the title of this PR (see https://sigs.k8s.io/cluster-api/CONTRIBUTING.md#contributing-a-patch), and delete this line and similar ones -->
<!-- the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) -->

**What this PR does / why we need it**:
This template further progresses #693 by adding cluster deployment and e2e testing templates.

The initial EMLB PR provided a provisioning template, but this one is now properly generated via kustomize and created as part of `make generate-templates`.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #