### PR TITLE
:bug: Add $(YQ) as a make dependency to generate-templates

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -285,7 +285,7 @@ generate: ## Generate code
 	$(MAKE) generate-templates
 
 .PHONY: generate-templates
-generate-templates: $(KUSTOMIZE) ## Generate cluster templates
+generate-templates: $(KUSTOMIZE) $(YQ) ## Generate cluster templates
 	$(KUSTOMIZE) build templates/development --load-restrictor LoadRestrictionsNone > templates/cluster-template-development.yaml
 	$(KUSTOMIZE) build templates/experimental-emlb --load-restrictor LoadRestrictionsNone > templates/cluster-template-emlb.yaml
 	$(KUSTOMIZE) build templates/experimental-emlb-crs-cni --load-restrictor LoadRestrictionsNone > templates/cluster-template-emlb-crs-cni.yaml


### PR DESCRIPTION
Signed-off-by: Chris Privitere <23177737+cprivitere@users.noreply.github.com>

<!-- please add an icon to the title of this PR (see https://sigs.k8s.io/cluster-api/CONTRIBUTING.md#contributing-a-patch), and delete this line and similar ones -->
<!-- the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) -->

**What this PR does / why we need it**:
make generate-templates doesn't ensure that yq has been compiled before trying to use it. Add $(YQ) to the dependencies line so it does so.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #779