### PR TITLE
Release-0.9.0

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,6 +1,6 @@
 run:
   timeout: 10m
-  go: "1.22"
+  go: "1.21"
   build-tags:
     - tools
     - e2e

--- a/Dockerfile
+++ b/Dockerfile
@@ -15,7 +15,7 @@
 # limitations under the License.
 
 # Build the manager binary
-ARG GOVER=1.22.5
+ARG GOVER=1.21.12
 FROM golang:${GOVER} as builder
 
 WORKDIR /workspace

--- a/clusterctl-settings.json
+++ b/clusterctl-settings.json
@@ -2,7 +2,7 @@
     "name": "infrastructure-packet",
     "config": {
       "componentsFile": "infrastructure-components.yaml",
-      "nextVersion": "v0.8.99"
+      "nextVersion": "v0.9.99"
     }
   }
   

--- a/docs/RELEASE.md
+++ b/docs/RELEASE.md
@@ -10,9 +10,20 @@ This is normally performed by our CI system. However, there are important steps 
 
 In order to cut a release, you must:
 
-1. If this is a new major or minor version - but **not** just a patch change - update [metadata.yaml](../metadata.yaml) to add it, and map it to the correct cluster-api contract version
-1. Update [packet-ci-actions.yaml](../test/e2e/config/packet-ci-actions.yaml) and [packet-ci.yaml](../test/e2e/config/packet-ci.yaml) to use the new version number for the current and/or new contract version of the packet InfrastructureProvider.
-1. If this is a new major or minor version - but **not** just a patch chagne - update [packet-ci-actions.yaml](../test/e2e/config/packet-ci-actions.yaml) and [packet-ci.yaml](../test/e2e/config/packet-ci.yaml) to have a new "next" version number for the latest contract version of the packet InfrastructureProvider.
+1. Update [packet-ci-actions.yaml](../test/e2e/config/packet-ci-actions.yaml) and [packet-ci.yaml](../test/e2e/config/packet-ci.yaml) to use the new version number for the current and/or new contract version of the packet InfrastructureProvider. (ie. v0.9.1)
+1. If this is a new major or minor version - but **not** just a patch change:
+
+   - Update [metadata.yaml](../metadata.yaml) to add it, and map it to the correct cluster-api contract version
+
+   ```yaml
+   - major: 0
+     minor: 10
+     contract: v1beta1
+   ```
+
+   - Update [packet-ci-actions.yaml](../test/e2e/config/packet-ci-actions.yaml) and [packet-ci.yaml](../test/e2e/config/packet-ci.yaml) to have a new "next" version number for the latest contract version of the packet InfrastructureProvider (ie. v0.11.99).
+   - Update clusterctl-settings.json to have the new "next" version number for the latest contract version of the packet InfrastructureProvider (ie. v0.11.99).
+
 1. Commit the changes.
 1. Push out your branch, open a PR and merge the changes
 1. Wait for the Continuous Integration github action to finish running
@@ -21,7 +32,7 @@ In order to cut a release, you must:
 
 ## How A Release Happens
 
-* GitHub Actions detects a new tag has been pushed
-* CI builds docker images for each supported architecture as well as a multi-arch manifest, and tags it with the semver tag of the release, e.g. `v0.4.0`
-* CI creates the release in `out/release`, the equivalent of `make release`
-* CI copies the artifacts in `out/release/*` to the github releases
+- GitHub Actions detects a new tag has been pushed
+- CI builds docker images for each supported architecture as well as a multi-arch manifest, and tags it with the semver tag of the release, e.g. `v0.4.0`
+- CI creates the release in `out/release`, the equivalent of `make release`
+- CI copies the artifacts in `out/release/*` to the github releases

--- a/docs/RELEASE.md
+++ b/docs/RELEASE.md
@@ -24,6 +24,7 @@ In order to cut a release, you must:
    - Update [packet-ci-actions.yaml](../test/e2e/config/packet-ci-actions.yaml) and [packet-ci.yaml](../test/e2e/config/packet-ci.yaml) to have a new "next" version number for the latest contract version of the packet InfrastructureProvider (ie. v0.11.99).
    - Update clusterctl-settings.json to have the new "next" version number for the latest contract version of the packet InfrastructureProvider (ie. v0.11.99).
 
+1. Review and update the versions of installed deployments like CPEM and kube-vip inside the templates.
 1. Commit the changes.
 1. Push out your branch, open a PR and merge the changes
 1. Wait for the Continuous Integration github action to finish running

--- a/hack/ensure-go.sh
+++ b/hack/ensure-go.sh
@@ -22,7 +22,7 @@ set -o pipefail
 verify_go_version() {
   if [[ -z "$(command -v go)" ]]; then
     if [[ "${INSTALL_GO:-"true"}" == "true" ]]; then
-      curl -sSL https://golang.org/dl/go${GO_VERSION:-"1.22"}.linux-amd64.tar.gz | tar -C /usr/local -xzf -
+      curl -sSL https://golang.org/dl/go${GO_VERSION:-"1.21"}.linux-amd64.tar.gz | tar -C /usr/local -xzf -
       export PATH=/usr/local/go/bin:$PATH
       export PATH=$(go env GOPATH)/bin:$PATH
     else
@@ -37,7 +37,7 @@ EOF
   local go_version
   IFS=" " read -ra go_version <<< "$(go version)"
   local minimum_go_version
-  minimum_go_version=go1.22
+  minimum_go_version=go1.21
   if [[ "${minimum_go_version}" != $(echo -e "${minimum_go_version}\n${go_version[2]}" | sort -s -t. -k 1,1 -k 2,2n -k 3,3n | head -n1) && "${go_version[2]}" != "devel" ]]; then
     cat <<EOF
 Detected go version: ${go_version[*]}.

--- a/metadata.yaml
+++ b/metadata.yaml
@@ -7,6 +7,9 @@ apiVersion: clusterctl.cluster.x-k8s.io/v1alpha3
 kind: Metadata
 releaseSeries:
 - major: 0
+  minor: 9
+  contract: v1beta1
+- major: 0
   minor: 8
   contract: v1beta1
 - major: 0

--- a/pkg/cloud/packet/client.go
+++ b/pkg/cloud/packet/client.go
@@ -358,7 +358,7 @@ func (p *Client) EnsureNodeBGPEnabled(ctx context.Context, id string) error {
 	_, response, err := p.DevicesApi.CreateBgpSession(ctx, id).BGPSessionInput(req).Execute() //nolint:bodyclose // see https://github.com/timakin/bodyclose/issues/42
 	// if we already had one, then we can ignore the error
 	// this really should be a 409, but 422 is what is returned
-	if response != nil && response.StatusCode == 422 && strings.Contains(err.Error(), "already has session") {
+	if response != nil && response.StatusCode == http.StatusUnprocessableEntity && strings.Contains(err.Error(), "already has session") {
 		err = nil
 	}
 	return err

--- a/templates/cluster-template-emlb-crs-cni.yaml
+++ b/templates/cluster-template-emlb-crs-cni.yaml
@@ -160,7 +160,7 @@ spec:
       echo "complete -o default -F __start_kubectl k" >> $HOME/.bashrc
       if [ -f "/run/kubeadm/kubeadm.yaml" ]; then
         export KUBECONFIG=/etc/kubernetes/admin.conf
-        export CPEM_YAML=https://github.com/equinix/cloud-provider-equinix-metal/releases/download/${CPEM_VERSION:=v3.8.0}/deployment.yaml
+        export CPEM_YAML=https://github.com/equinix/cloud-provider-equinix-metal/releases/download/${CPEM_VERSION:=v3.8.1}/deployment.yaml
         export SECRET_DATA='cloud-sa.json=''{"apiKey": "{{ .apiKey }}","projectID": "${PROJECT_ID}"}'''
         kubectl create secret generic -n kube-system metal-cloud-config --from-literal="$${SECRET_DATA}" || (sleep 1 && kubectl create secret generic -n kube-system metal-cloud-config --from-literal="$${SECRET_DATA}") || (sleep 1 && kubectl create secret generic -n kube-system metal-cloud-config --from-literal="$${SECRET_DATA}")
         kubectl apply -f $${CPEM_YAML} || (sleep 1 && kubectl apply -f $${CPEM_YAML}) || (sleep 1 && kubectl apply -f $${CPEM_YAML})

--- a/templates/cluster-template-emlb.yaml
+++ b/templates/cluster-template-emlb.yaml
@@ -139,7 +139,7 @@ spec:
       echo "complete -o default -F __start_kubectl k" >> $HOME/.bashrc
       if [ -f "/run/kubeadm/kubeadm.yaml" ]; then
         export KUBECONFIG=/etc/kubernetes/admin.conf
-        export CPEM_YAML=https://github.com/equinix/cloud-provider-equinix-metal/releases/download/${CPEM_VERSION:=v3.8.0}/deployment.yaml
+        export CPEM_YAML=https://github.com/equinix/cloud-provider-equinix-metal/releases/download/${CPEM_VERSION:=v3.8.1}/deployment.yaml
         export SECRET_DATA='cloud-sa.json=''{"apiKey": "{{ .apiKey }}","projectID": "${PROJECT_ID}"}'''
         kubectl create secret generic -n kube-system metal-cloud-config --from-literal="$${SECRET_DATA}" || (sleep 1 && kubectl create secret generic -n kube-system metal-cloud-config --from-literal="$${SECRET_DATA}") || (sleep 1 && kubectl create secret generic -n kube-system metal-cloud-config --from-literal="$${SECRET_DATA}")
         kubectl apply -f $${CPEM_YAML} || (sleep 1 && kubectl apply -f $${CPEM_YAML}) || (sleep 1 && kubectl apply -f $${CPEM_YAML})

--- a/templates/cluster-template-kube-vip-crs-cni.yaml
+++ b/templates/cluster-template-kube-vip-crs-cni.yaml
@@ -165,9 +165,10 @@ spec:
         kubectl create secret generic -n kube-system metal-cloud-config --from-literal="$${SECRET_DATA}" || (sleep 1 && kubectl create secret generic -n kube-system metal-cloud-config --from-literal="$${SECRET_DATA}") || (sleep 1 && kubectl create secret generic -n kube-system metal-cloud-config --from-literal="$${SECRET_DATA}")
         kubectl apply -f $${CPEM_YAML} || (sleep 1 && kubectl apply -f $${CPEM_YAML}) || (sleep 1 && kubectl apply -f $${CPEM_YAML})
       else
-        KVVERSION="${KUBE_VIP_VERSION:=v0.6.4}"
+        KVVERSION="${KUBE_VIP_VERSION:=v0.8.1}"
         ctr image pull ghcr.io/kube-vip/kube-vip:$${KVVERSION}
         ctr run --rm --net-host ghcr.io/kube-vip/kube-vip:$KVVERSION vip /kube-vip manifest pod \
+        --cidr 32 \
         --interface "lo" \
         --vip "{{ .controlPlaneEndpoint }}" \
         --controlplane \
@@ -225,9 +226,10 @@ spec:
       done
       if [ -f "/run/kubeadm/kubeadm.yaml" ]; then
         ip addr add {{ .controlPlaneEndpoint }} dev lo
-        KVVERSION="${KUBE_VIP_VERSION:=v0.6.4}"
+        KVVERSION="${KUBE_VIP_VERSION:=v0.8.1}"
         ctr image pull ghcr.io/kube-vip/kube-vip:$${KVVERSION}
         ctr run --rm --net-host ghcr.io/kube-vip/kube-vip:$KVVERSION vip /kube-vip manifest pod \
+        --cidr 32 \
         --interface "lo" \
         --vip "{{ .controlPlaneEndpoint }}" \
         --controlplane \

--- a/templates/cluster-template-kube-vip.yaml
+++ b/templates/cluster-template-kube-vip.yaml
@@ -144,9 +144,10 @@ spec:
         kubectl create secret generic -n kube-system metal-cloud-config --from-literal="$${SECRET_DATA}" || (sleep 1 && kubectl create secret generic -n kube-system metal-cloud-config --from-literal="$${SECRET_DATA}") || (sleep 1 && kubectl create secret generic -n kube-system metal-cloud-config --from-literal="$${SECRET_DATA}")
         kubectl apply -f $${CPEM_YAML} || (sleep 1 && kubectl apply -f $${CPEM_YAML}) || (sleep 1 && kubectl apply -f $${CPEM_YAML})
       else
-        KVVERSION="${KUBE_VIP_VERSION:=v0.6.4}"
+        KVVERSION="${KUBE_VIP_VERSION:=v0.8.1}"
         ctr image pull ghcr.io/kube-vip/kube-vip:$${KVVERSION}
         ctr run --rm --net-host ghcr.io/kube-vip/kube-vip:$KVVERSION vip /kube-vip manifest pod \
+        --cidr 32 \
         --interface "lo" \
         --vip "{{ .controlPlaneEndpoint }}" \
         --controlplane \
@@ -204,9 +205,10 @@ spec:
       done
       if [ -f "/run/kubeadm/kubeadm.yaml" ]; then
         ip addr add {{ .controlPlaneEndpoint }} dev lo
-        KVVERSION="${KUBE_VIP_VERSION:=v0.6.4}"
+        KVVERSION="${KUBE_VIP_VERSION:=v0.8.1}"
         ctr image pull ghcr.io/kube-vip/kube-vip:$${KVVERSION}
         ctr run --rm --net-host ghcr.io/kube-vip/kube-vip:$KVVERSION vip /kube-vip manifest pod \
+        --cidr 32 \
         --interface "lo" \
         --vip "{{ .controlPlaneEndpoint }}" \
         --controlplane \

--- a/templates/experimental-emlb/kustomization.yaml
+++ b/templates/experimental-emlb/kustomization.yaml
@@ -75,7 +75,7 @@ patches:
               echo "complete -o default -F __start_kubectl k" >> $HOME/.bashrc
               if [ -f "/run/kubeadm/kubeadm.yaml" ]; then
                 export KUBECONFIG=/etc/kubernetes/admin.conf
-                export CPEM_YAML=https://github.com/equinix/cloud-provider-equinix-metal/releases/download/${CPEM_VERSION:=v3.8.0}/deployment.yaml
+                export CPEM_YAML=https://github.com/equinix/cloud-provider-equinix-metal/releases/download/${CPEM_VERSION:=v3.8.1}/deployment.yaml
                 export SECRET_DATA='cloud-sa.json=''{"apiKey": "{{ .apiKey }}","projectID": "${PROJECT_ID}"}'''
                 kubectl create secret generic -n kube-system metal-cloud-config --from-literal="$${SECRET_DATA}" || (sleep 1 && kubectl create secret generic -n kube-system metal-cloud-config --from-literal="$${SECRET_DATA}") || (sleep 1 && kubectl create secret generic -n kube-system metal-cloud-config --from-literal="$${SECRET_DATA}")
                 kubectl apply -f $${CPEM_YAML} || (sleep 1 && kubectl apply -f $${CPEM_YAML}) || (sleep 1 && kubectl apply -f $${CPEM_YAML})

--- a/templates/experimental-kube-vip/kustomization.yaml
+++ b/templates/experimental-kube-vip/kustomization.yaml
@@ -65,9 +65,10 @@ patches:
               done
               if [ -f "/run/kubeadm/kubeadm.yaml" ]; then
                 ip addr add {{ .controlPlaneEndpoint }} dev lo
-                KVVERSION="${KUBE_VIP_VERSION:=v0.6.4}"
+                KVVERSION="${KUBE_VIP_VERSION:=v0.8.1}"
                 ctr image pull ghcr.io/kube-vip/kube-vip:$${KVVERSION}
                 ctr run --rm --net-host ghcr.io/kube-vip/kube-vip:$KVVERSION vip /kube-vip manifest pod \
+                --cidr 32 \
                 --interface "lo" \
                 --vip "{{ .controlPlaneEndpoint }}" \
                 --controlplane \
@@ -91,9 +92,10 @@ patches:
                 kubectl create secret generic -n kube-system metal-cloud-config --from-literal="$${SECRET_DATA}" || (sleep 1 && kubectl create secret generic -n kube-system metal-cloud-config --from-literal="$${SECRET_DATA}") || (sleep 1 && kubectl create secret generic -n kube-system metal-cloud-config --from-literal="$${SECRET_DATA}")
                 kubectl apply -f $${CPEM_YAML} || (sleep 1 && kubectl apply -f $${CPEM_YAML}) || (sleep 1 && kubectl apply -f $${CPEM_YAML})
               else
-                KVVERSION="${KUBE_VIP_VERSION:=v0.6.4}"
+                KVVERSION="${KUBE_VIP_VERSION:=v0.8.1}"
                 ctr image pull ghcr.io/kube-vip/kube-vip:$${KVVERSION}
                 ctr run --rm --net-host ghcr.io/kube-vip/kube-vip:$KVVERSION vip /kube-vip manifest pod \
+                --cidr 32 \
                 --interface "lo" \
                 --vip "{{ .controlPlaneEndpoint }}" \
                 --controlplane \

--- a/test/e2e/common_test.go
+++ b/test/e2e/common_test.go
@@ -65,13 +65,13 @@ func (wc *wrappedClient) IsObjectNamespaced(obj runtime.Object) (namespaced bool
 type wrappedClusterProxy struct {
 	clusterProxy framework.ClusterProxy
 
-	clusterNames sets.String
+	clusterNames sets.Set[string]
 }
 
 func NewWrappedClusterProxy(name string, kubeconfigPath string, scheme *runtime.Scheme, options ...framework.Option) *wrappedClusterProxy {
 	return &wrappedClusterProxy{
 		clusterProxy: framework.NewClusterProxy(name, kubeconfigPath, scheme, options...),
-		clusterNames: sets.NewString(),
+		clusterNames: sets.New[string](),
 	}
 }
 

--- a/test/e2e/config/packet-ci-actions.yaml
+++ b/test/e2e/config/packet-ci-actions.yaml
@@ -13,8 +13,8 @@ providers:
   - name: cluster-api
     type: CoreProvider
     versions:
-      - name: v1.7.3 # latest published release in the v1beta1 series
-        value: "https://github.com/kubernetes-sigs/cluster-api/releases/download/v1.7.3/core-components.yaml"
+      - name: v1.7.4 # latest published release in the v1beta1 series
+        value: "https://github.com/kubernetes-sigs/cluster-api/releases/download/v1.7.4/core-components.yaml"
         type: "url"
         contract: v1beta1
         replacements:
@@ -26,8 +26,8 @@ providers:
   - name: kubeadm
     type: BootstrapProvider
     versions:
-      - name: v1.7.3 # latest published release in the v1beta1 series
-        value: "https://github.com/kubernetes-sigs/cluster-api/releases/download/v1.7.3/bootstrap-components.yaml"
+      - name: v1.7.4 # latest published release in the v1beta1 series
+        value: "https://github.com/kubernetes-sigs/cluster-api/releases/download/v1.7.4/bootstrap-components.yaml"
         type: "url"
         contract: v1beta1
         replacements:
@@ -39,8 +39,8 @@ providers:
   - name: kubeadm
     type: ControlPlaneProvider
     versions:
-      - name: v1.7.3 # latest published release in the v1beta1 series; this is used for v1beta1 --> main clusterctl upgrades test only.
-        value: "https://github.com/kubernetes-sigs/cluster-api/releases/download/v1.7.3/control-plane-components.yaml"
+      - name: v1.7.4 # latest published release in the v1beta1 series; this is used for v1beta1 --> main clusterctl upgrades test only.
+        value: "https://github.com/kubernetes-sigs/cluster-api/releases/download/v1.7.4/control-plane-components.yaml"
         type: "url"
         contract: v1beta1
         replacements:
@@ -52,18 +52,20 @@ providers:
   - name: packet
     type: InfrastructureProvider
     versions:
-      - name: v0.8.0
+      - name: v0.9.0 #latest in the v1beta1 series
         value: "${MANIFEST_PATH:=..}/infrastructure-components.yaml"
         type: "url"
         contract: v1beta1
         files:
           - sourcePath: "${MANIFEST_PATH:=..}/metadata.yaml"
           - sourcePath: "../data/v1beta1/cluster-template.yaml"
+          - sourcePath: "../data/v1beta1/cluster-template-emlb.yaml"
+          - sourcePath: "../data/v1beta1/cluster-template-kube-vip.yaml"
           - sourcePath: "../data/v1beta1/cluster-template-kcp-scale-in.yaml"
           - sourcePath: "../data/v1beta1/cluster-template-node-drain.yaml"
           - sourcePath: "../data/v1beta1/cluster-template-md-remediation.yaml"
           - sourcePath: "../data/v1beta1/cluster-template-kcp-remediation.yaml"
-      - name: v0.8.99 # next; use manifest from source files
+      - name: v0.9.99 # next; use manifest from source files
         value: "${MANIFEST_PATH:=..}/infrastructure-components.yaml"
         type: "url"
         contract: v1beta1
@@ -78,12 +80,13 @@ providers:
           - sourcePath: "../data/v1beta1/cluster-template-kcp-remediation.yaml"
 
 variables:
-  KUBERNETES_VERSION_MANAGEMENT: "v1.28.0"
-  KUBERNETES_VERSION: "${KUBERNETES_VERSION:-v1.28.0}"
-  KUBERNETES_VERSION_UPGRADE_FROM: "v1.27.3"
-  KUBERNETES_VERSION_UPGRADE_TO: "v1.28.0"
-  ETCD_VERSION_UPGRADE_TO: "3.5.9-0"
-  COREDNS_VERSION_UPGRADE_TO: "v1.10.1"
+  # Update to versions matching https://github.com/kubernetes-sigs/cluster-api/blob/v{VERSION}/test/e2e/config/docker.yaml
+  KUBERNETES_VERSION_MANAGEMENT: "v1.30.0"
+  KUBERNETES_VERSION: "${KUBERNETES_VERSION:-v1.30.0}"
+  KUBERNETES_VERSION_UPGRADE_FROM: "v1.29.4"
+  KUBERNETES_VERSION_UPGRADE_TO: "v1.30.0"
+  ETCD_VERSION_UPGRADE_TO: "3.5.12-0"
+  COREDNS_VERSION_UPGRADE_TO: "v1.11.1"
 
   # Infra provider specific variables
   NODE_OS: "ubuntu_20_04"

--- a/test/e2e/config/packet-ci.yaml
+++ b/test/e2e/config/packet-ci.yaml
@@ -13,8 +13,8 @@ providers:
   - name: cluster-api
     type: CoreProvider
     versions:
-      - name: v1.7.3 # latest published release in the v1beta1 series
-        value: "https://github.com/kubernetes-sigs/cluster-api/releases/download/v1.7.3/core-components.yaml"
+      - name: v1.7.4 # latest published release in the v1beta1 series
+        value: "https://github.com/kubernetes-sigs/cluster-api/releases/download/v1.7.4/core-components.yaml"
         type: "url"
         contract: v1beta1
         replacements:
@@ -26,8 +26,8 @@ providers:
   - name: kubeadm
     type: BootstrapProvider
     versions:
-      - name: v1.7.3 # latest published release in the v1beta1 series
-        value: "https://github.com/kubernetes-sigs/cluster-api/releases/download/v1.7.3/bootstrap-components.yaml"
+      - name: v1.7.4 # latest published release in the v1beta1 series
+        value: "https://github.com/kubernetes-sigs/cluster-api/releases/download/v1.7.4/bootstrap-components.yaml"
         type: "url"
         contract: v1beta1
         replacements:
@@ -39,8 +39,8 @@ providers:
   - name: kubeadm
     type: ControlPlaneProvider
     versions:
-      - name: v1.7.3 # latest published release in the v1beta1 series; this is used for v1beta1 --> main clusterctl upgrades test only.
-        value: "https://github.com/kubernetes-sigs/cluster-api/releases/download/v1.7.3/control-plane-components.yaml"
+      - name: v1.7.4 # latest published release in the v1beta1 series; this is used for v1beta1 --> main clusterctl upgrades test only.
+        value: "https://github.com/kubernetes-sigs/cluster-api/releases/download/v1.7.4/control-plane-components.yaml"
         type: "url"
         contract: v1beta1
         replacements:
@@ -52,24 +52,8 @@ providers:
   - name: packet
     type: InfrastructureProvider
     versions:
-      - name: v0.8.0 #latest in the v1beta1 series
+      - name: v0.9.0 #latest in the v1beta1 series
         value: "../../../config/default"
-        replacements:
-          - old: "image: .*/cluster-api-provider-packet:.*"
-            new: "image: ${REGISTRY:=quay.io}/${IMAGE_NAME:=kubernetes-sigs/cluster-api-provider-packet}:${TAG:=e2e}"
-        contract: v1beta1
-        files:
-          - sourcePath: "../../../metadata.yaml"
-          - sourcePath: "../data/v1beta1/cluster-template.yaml"
-          - sourcePath: "../data/v1beta1/cluster-template-kcp-scale-in.yaml"
-          - sourcePath: "../data/v1beta1/cluster-template-node-drain.yaml"
-          - sourcePath: "../data/v1beta1/cluster-template-md-remediation.yaml"
-          - sourcePath: "../data/v1beta1/cluster-template-kcp-remediation.yaml"
-      - name: v0.8.99 # next; use manifest from source files
-        value: "../../../config/default"
-        replacements:
-          - old: "image: .*/cluster-api-provider-packet:.*"
-            new: "image: ${REGISTRY:=quay.io}/${IMAGE_NAME:=kubernetes-sigs/cluster-api-provider-packet}:${TAG:=e2e}"
         contract: v1beta1
         files:
           - sourcePath: "../../../metadata.yaml"
@@ -80,11 +64,8 @@ providers:
           - sourcePath: "../data/v1beta1/cluster-template-node-drain.yaml"
           - sourcePath: "../data/v1beta1/cluster-template-md-remediation.yaml"
           - sourcePath: "../data/v1beta1/cluster-template-kcp-remediation.yaml"
-      - name: v1.7.99 # next; use manifest from source files
+      - name: v0.9.99 # next; use manifest from source files
         value: "../../../config/default"
-        replacements:
-          - old: "image: .*/cluster-api-provider-packet:.*"
-            new: "image: ${REGISTRY:=quay.io}/${IMAGE_NAME:=kubernetes-sigs/cluster-api-provider-packet}:${TAG:=e2e}"
         contract: v1beta1
         files:
           - sourcePath: "../../../metadata.yaml"
@@ -98,12 +79,12 @@ providers:
 
 variables:
   # Update to versions matching https://github.com/kubernetes-sigs/cluster-api/blob/v{VERSION}/test/e2e/config/docker.yaml
-  KUBERNETES_VERSION_MANAGEMENT: "v1.28.0"
-  KUBERNETES_VERSION: "${KUBERNETES_VERSION:-v1.28.0}"
-  KUBERNETES_VERSION_UPGRADE_FROM: "v1.27.3"
-  KUBERNETES_VERSION_UPGRADE_TO: "v1.28.0"
-  ETCD_VERSION_UPGRADE_TO: "3.5.9-0"
-  COREDNS_VERSION_UPGRADE_TO: "v1.10.1"
+  KUBERNETES_VERSION_MANAGEMENT: "v1.30.0"
+  KUBERNETES_VERSION: "${KUBERNETES_VERSION:-v1.30.0}"
+  KUBERNETES_VERSION_UPGRADE_FROM: "v1.29.4"
+  KUBERNETES_VERSION_UPGRADE_TO: "v1.30.0"
+  ETCD_VERSION_UPGRADE_TO: "3.5.12-0"
+  COREDNS_VERSION_UPGRADE_TO: "v1.11.1"
 
   # Infra provider specific variables
   NODE_OS: "ubuntu_20_04"


### PR DESCRIPTION
<!-- please add an icon to the title of this PR (see https://sigs.k8s.io/cluster-api/CONTRIBUTING.md#contributing-a-patch), and delete this line and similar ones -->
<!-- the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) -->

**What this PR does / why we need it**: 
Release prep for v0.9.0
- Bump versions to v0.9.0
- Update release docs to mention more things that need to be bumped during a version
- Move golang in Makefile back to 1.21 to fix CI building
- Fix areas of e2e tests to better support EMLB testing and cleanup as well as remove some deprecations

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #