### PR TITLE
Update OWNERS_ALIASES and remove cprivitere

### DIFF
--- a/OWNERS_ALIASES
+++ b/OWNERS_ALIASES
@@ -4,12 +4,13 @@ aliases:
   - fabriziopandini
   - justinsb
   - neolit123
-  - timothysc
+  - vincepri
   cluster-api-admins:
-  - CecileRobertMichon
+  - fabriziopandini
+  - sbueringer
   - vincepri
   cluster-api-maintainers:
-  - CecileRobertMichon
+  - chrischdi
   - enxebre
   - fabriziopandini
   - sbueringer

--- a/OWNERS_ALIASES
+++ b/OWNERS_ALIASES
@@ -16,7 +16,6 @@ aliases:
   - sbueringer
   - vincepri
   cluster-api-packet-maintainers:
-  - cprivitere
   - deitch
   - detiber
   - displague


### PR DESCRIPTION
Signed-off-by: cprivitere <23177737+cprivitere@users.noreply.github.com>

<!-- please add an icon to the title of this PR (see https://sigs.k8s.io/cluster-api/CONTRIBUTING.md#contributing-a-patch), and delete this line and similar ones -->
<!-- the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) -->

**What this PR does / why we need it**: 
- The OWNERS_ALIASES file had incorrect members in the various upstream Cluster API and SIG Cluster Lifecycle groups, so I've updated those to the current memberships. 
- Second, I'm removing myself from the OWNERS file since I no longer work at Equinix and no longer maintain this project.
